### PR TITLE
Remove `container-linux-config` tag suffix from code blocks

### DIFF
--- a/coreupdate/configure-machines.md
+++ b/coreupdate/configure-machines.md
@@ -24,7 +24,7 @@ For example, here is what the Alpha group looks like in CoreUpdate:
 
 Here's the Container Linux Config to use:
 
-```yaml container-linux-config
+```yaml
 update:
   group:  alpha
   server: https://customer.update.core-os.net/v1/update/
@@ -40,7 +40,7 @@ For example, here is what "NYC Production" looks like in CoreUpdate:
 
 Here's the Container Linux Config to use:
 
-```yaml container-linux-config
+```yaml
 update:
   group:  0a809ab1-c01c-4a6b-8ac8-6b17cb9bae09
   server: https://customer.update.core-os.net/v1/update/

--- a/etcd/etcd-live-cluster-reconfiguration.md
+++ b/etcd/etcd-live-cluster-reconfiguration.md
@@ -6,7 +6,7 @@ This document describes the reconfiguration and recovery of an etcd cluster runn
 
 When a [Container Linux Config][cl-configs] is used for configuring an etcd member on a Container Linux node, it compiles a special `/etc/systemd/system/etcd-member.service.d/20-clct-etcd-member.conf` [drop-in unit file][drop-in]. For example:
 
-```yaml container-linux-config
+```yaml
 etcd:
   name: demo-etcd-1
   listen_client_urls: http://10.240.0.1:2379,http://0.0.0.0:4001
@@ -61,7 +61,7 @@ Changing the size of an etcd cluster is as simple as adding a new member, and us
 
 3. Use the information from the output of the `etcdctl member add` command and provision a new Container Linux host with the following Container Linux Config:
 
-    ```yaml container-linux-config
+    ```yaml
     etcd:
       name: node4
       listen_client_urls: http://10.240.0.4:2379,http://0.0.0.0:4001
@@ -89,7 +89,7 @@ An etcd member node might fail for several reasons: out of disk space, an incorr
 
 Consider a scenario where a member is failed in a three-member cluster. The cluster is still running and has maintained [quorum][majority].  The example assumes [a Container Linux Config][cl-configs] is used with the following default options:
 
-```yaml container-linux-config
+```yaml
 etcd:
   name: demo-etcd-1
   listen_client_urls: http://10.240.0.1:2379,http://0.0.0.0:4001
@@ -142,7 +142,7 @@ cluster is healthy
 
 4. Modify the existing systemd drop-in, `/etc/systemd/system/etcd-member.service.d/20-clct-etcd-member.conf` by replacing the node data with the appropriate information from the output of the `etcdctl member add` command executed in the last step.
 
-    ```yaml container-linux-config
+    ```yaml
     etcd:
       name: demo-etcd-2
       listen_client_urls: http://10.240.0.2:2379,http://0.0.0.0:4001

--- a/etcd/getting-started-with-etcd.md
+++ b/etcd/getting-started-with-etcd.md
@@ -18,7 +18,7 @@ To upgrade an existing etcd v2 cluster rather than deploy a new one, start with 
 
 A Container Linux Config can be used to set any etcd option, like in this example:
 
-```yaml container-linux-config
+```yaml
 etcd:
   name:                        my-etcd-1
   listen_client_urls:          https://10.240.0.1:2379

--- a/etcd/tls-etcd-clients.md
+++ b/etcd/tls-etcd-clients.md
@@ -14,7 +14,7 @@ This document assumes three Container Linux nodes will be booted and will be run
 
 Flannel options can be specified in a Container Linux Config. For an example, this is a config that sets the etcd endpoints flannel will use and specifies tls resources to encrypt the connection:
 
-```yaml container-linux-config
+```yaml
 flannel:
   etcd_endpoints: "https://172.16.0.101:2379,https://172.16.0.102:2379,https://172.16.0.103:2379"
   etcd_cafile:    /etc/ssl/etcd/ca.pem
@@ -28,7 +28,7 @@ Suppose you're using `/etc/etcd/ssl` instead, you will need to adjust the flanne
  
 A complete example would look like:
 
-```yaml container-linux-config
+```yaml
 flannel:
   etcd_endpoints: "https://172.16.0.101:2379,https://172.16.0.102:2379,https://172.16.0.103:2379"
   etcd_cafile:    /etc/ssl/etcd/ca.pem
@@ -47,7 +47,7 @@ systemd:
 
 Due to the [deprecation of fleet][fleet-deprecation], Container Linux Configs don't have a convenient syntax for configuring fleet like for flannel. Fleet can still be easily configured however with the use of a systemd drop-in.
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: fleet.service
@@ -67,7 +67,7 @@ systemd:
 
 Example Container Linux Config excerpt for Locksmith configuration:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: locksmithd.service

--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -26,7 +26,7 @@ $ etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
 
 You can put this into a drop-in for flanneld.service via a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: flanneld.service
@@ -47,7 +47,7 @@ flannel uses UDP port 8285 for sending encapsulated IP packets. Make sure to ena
 
 The last step is to enable `flanneld.service` by creating the `flannel` section in our Container Linux Config. Options for flannel can be specified in this section.
 
-```yaml container-linux-config
+```yaml
 flannel: ~
 ```
 
@@ -57,7 +57,7 @@ flannel: ~
 
 Flannel requires SSL certificates to communicate with a secure etcd cluster. By default, flannel looks for these certificates in `/etc/ssl/etcd`. To use different certificates, add `Environment=ETCD_SSL_DIR` to a drop-in file for `flanneld.service`. Use the following configuration snippet to achieve this:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: flanneld.service

--- a/fleet/launching-containers-fleet.md
+++ b/fleet/launching-containers-fleet.md
@@ -297,7 +297,7 @@ MachineMetadata=region=east
 
 On Container Linux, only fleet 0.11.x is available under /usr/bin. That one might be obsolete for users who want to try out more recent versions. In that case, users should define their own custom Container Linux Config to be able to run any version of fleet as they want. For example:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /opt/bin/fleet-wrapper

--- a/os/adding-swap.md
+++ b/os/adding-swap.md
@@ -80,7 +80,7 @@ The block device mounted at `/var/`, `/dev/sdXN`, is the correct filesystem type
 
 The following config sets up a 1GiB swapfile located at `/var/vm/swapfile1`.
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
   - path: /etc/sysctl.d/80-swappiness.conf

--- a/os/adding-users.md
+++ b/os/adding-users.md
@@ -6,7 +6,7 @@ You can create user accounts on a Flatcar Linux machine manually with `useradd` 
 
 In your Container Linux Config, you can specify many [different parameters](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md) for each user. Here's an example:
 
-```yaml container-linux-config
+```yaml
 passwd:
   users:
     - name: core

--- a/os/booting-on-azure.md
+++ b/os/booting-on-azure.md
@@ -42,7 +42,7 @@ You can provide a raw Ignition config (produced from a Container Linux Config) t
 
 As an example, this config will configure and start etcd:
 
-```yaml container-linux-config:azure
+```yaml
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -122,7 +122,7 @@ You can provide a raw Ignition config to Flatcar Linux via the Amazon web consol
 
 As an example, this Container Linux Config will configure and start etcd:
 
-```yaml container-linux-config:ec2
+```yaml
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.
@@ -146,7 +146,7 @@ etcd:
 
 Ephemeral disks and additional EBS volumes attached to instances can be mounted with a `.mount` unit. Amazon's block storage devices are attached differently [depending on the instance type](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames). Here's the Container Linux Config to format and mount the first ephemeral disk, `xvdb`, on most instance types:
 
-```yaml container-linux-config:ec2
+```yaml
 storage:
   filesystems:
     - mount:
@@ -257,7 +257,7 @@ First we need to create a security group to allow Flatcar Linux instances to com
         </li>
         <li>
           Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
-          ```yaml container-linux-config:ec2
+          ```yaml
           etcd:
             # All options get passed as command line flags to etcd.
             # Any information inside curly braces comes from the machine at boot time.
@@ -331,7 +331,7 @@ First we need to create a security group to allow Flatcar Linux instances to com
         </li>
         <li>
           Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
-          ```yaml container-linux-config:ec2
+          ```yaml
           etcd:
             # All options get passed as command line flags to etcd.
             # Any information inside curly braces comes from the machine at boot time.
@@ -405,7 +405,7 @@ First we need to create a security group to allow Flatcar Linux instances to com
         </li>
         <li>
           Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
-          ```yaml container-linux-config:ec2
+          ```yaml
           etcd:
             # All options get passed as command line flags to etcd.
             # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -10,7 +10,7 @@ When booting your [Flatcar Linux Machines on EC2](booting-on-ec2.md), configure 
 
 Be sure to change `ECS_CLUSTER` to the cluster name you've configured via the ECS CLI or leave it empty for the default. Here's a full config example:
 
-```yaml container-linux-config:ec2
+```yaml
 systemd:
  units:
    - name: amazon-ecs-agent.service

--- a/os/booting-on-google-compute-engine.md
+++ b/os/booting-on-google-compute-engine.md
@@ -16,7 +16,7 @@ You can provide a raw Ignition config to Flatcar Linux via the Google Cloud cons
 
 As an example, this config will configure and start etcd:
 
-```yaml container-linux-config:gce
+```yaml
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.
@@ -67,7 +67,7 @@ Create 3 instances from the image above using our Ignition from `example.ign`:
 
 Additional disks attached to instances can be mounted with a `.mount` unit. Each disk can be accessed via `/dev/disk/by-id/google-<disk-name>`. Here's the Container Linux Config to format and mount a disk called `database-backup`:
 
-```yaml container-linux-config:gce
+```yaml
 storage:
   filesystems:
     - mount:

--- a/os/booting-on-openstack.md
+++ b/os/booting-on-openstack.md
@@ -80,7 +80,7 @@ Flatcar Linux allows you to configure machine parameters, launch systemd units o
 
 A common Container Linux Config for OpenStack looks like:
 
-```yaml container-linux-config:openstack-metadata
+```yaml
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-packet.md
+++ b/os/booting-on-packet.md
@@ -39,7 +39,7 @@ You can provide a raw Ignition config to Flatcar Linux via Packet's userdata fie
 
 As an example, this config will configure and start etcd:
 
-```yaml container-linux-config:packet
+```yaml
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -79,7 +79,7 @@ You can provide a raw Ignition config to Flatcar Linux via VMware's [Guestinfo i
 
 As an example, this config will start etcd:
 
-```yaml container-linux-config
+```yaml
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-with-libvirt.md
+++ b/os/booting-with-libvirt.md
@@ -95,7 +95,7 @@ restorecon -R "/var/lib/libvirt/container-linux/container-linux1"
 
 A simple Flatcar Linux config to add your ssh keys might look like the following:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
   - path: /etc/hostname
@@ -193,7 +193,7 @@ Expiry Time          MAC address        Protocol  IP address                Host
 
 By default, Flatcar Linux uses DHCP to get its network configuration. In this example the VM will be attached directly to the local network via a bridge on the host's virbr0 and the local network. To configure a static address add a [networkd unit][systemd-network] to the Flatcar Linux config:
 
-```yaml container-linux-config
+```yaml
 passwd:
   users:
   - name: core

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -44,7 +44,7 @@ label flatcar
 
 Here's a common config example which should be located at the URL from above:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: etcd2.service
@@ -147,7 +147,7 @@ If you plan on using Docker we recommend using a local ext4 filesystem with over
 
 For example, to setup an ext4 root filesystem on `/dev/sda`:
 
-```yaml container-linux-config
+```yaml
 storage:
   disks:
   - device: /dev/sda
@@ -166,7 +166,7 @@ And add `root=/dev/sda1` or `root=LABEL=ROOT` to the kernel options as documente
 
 Similarly, to setup a btrfs root filesystem on `/dev/sda`:
 
-```yaml container-linux-config
+```yaml
 storage:
   disks:
   - device: /dev/sda

--- a/os/cluster-architectures.md
+++ b/os/cluster-architectures.md
@@ -21,7 +21,7 @@ If you're developing locally but plan to run containers in production, it's best
 
 Start a single Flatcar Linux VM with the Docker remote socket enabled in the Container Linux Config (CL Config). Here's what the CL Config looks like:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: docker-tcp.socket
@@ -115,7 +115,7 @@ The networkd unit is typically used for bare metal installations that require st
 
 Here's the CL Config for the etcd machine:
 
-```yaml container-linux-config
+```yaml
 etcd:
   version: 3.1.5
   name: "etcdserver"
@@ -169,7 +169,7 @@ Our central services machines will run services like etcd and Kubernetes control
 
 Here's an example CL Config for one of the central service machines. Be sure to generate a new discovery token with the initial size of your cluster:
 
-```yaml container-linux-config
+```yaml
 etcd:
   version: 3.0.15
   # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
@@ -208,7 +208,7 @@ The worker roles will use DHCP and should be easy to add capacity or autoscaling
 
 Here's an example CL Config for a worker which specifies an update channel:
 
-```yaml container-linux-config
+```yaml
 update:
   # CoreUpdate group ID for "Production Central Services"
   # Use "stable", "beta", or "alpha" for non-subscribers.

--- a/os/cluster-discovery.md
+++ b/os/cluster-discovery.md
@@ -15,7 +15,7 @@ The discovery URL can be provided to each Flatcar Linux machine via [Container L
 
 Boot each one of the machines with identical Container Linux Config and they should be automatically clustered:
 
-```yaml container-linux-config:ec2
+```yaml
 etcd:
   # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
   # specify the initial size of your cluster with ?size=X

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -121,7 +121,7 @@ $ sudo systemctl restart systemd-networkd
 
 NTP time sources can be set in `timesyncd.conf` with a [Container Linux Config][cl-configs] snippet like:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/systemd/timesyncd.conf
@@ -147,7 +147,7 @@ $ sudo systemctl start ntpd
 
 or with this Container Linux Config snippet:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: systemd-timesyncd.service
@@ -179,7 +179,7 @@ $ sudo systemctl reload ntpd
 
 Or, in a [Container Linux Config][cl-configs]:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/ntp.conf

--- a/os/configuring-dns.md
+++ b/os/configuring-dns.md
@@ -8,7 +8,7 @@ By default, DNS resolution on Flatcar Linux is handled through `/etc/resolv.conf
 
 Here is an example [Container Linux Config][cl-configs] snippet to do that:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/nsswitch.conf

--- a/os/customize-etcd-unit.md
+++ b/os/customize-etcd-unit.md
@@ -8,7 +8,7 @@ etcd supports client certificates as a way to provide secure communication betwe
 
 Please follow the [instruction](generate-self-signed-certificates.md) to know how to create self-signed certificates and private keys.
 
-```yaml container-linux-config
+```yaml
 etcd:
   # More settings are needed here for a functioning etcd daemon
   ca_file:        /path/to/CA.pem

--- a/os/customizing-docker.md
+++ b/os/customizing-docker.md
@@ -38,7 +38,7 @@ docker -H tcp://127.0.0.1:2375 ps
 
 To enable the remote API on every Flatcar Linux machine in a cluster, use a [Container Linux Config][cl-configs]. We need to provide the new socket file and Docker's socket activation support will automatically start using the socket:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: docker-tcp.socket
@@ -162,7 +162,7 @@ docker images
 
 A Container Linux Config for Docker TLS authentication will look like:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/docker/ca.pem
@@ -249,7 +249,7 @@ journalctl -u docker
 
 If you need to modify a flag across many machines, you can add the flag with a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 docker:
   flags:
     - --debug
@@ -283,7 +283,7 @@ Proxy environment variables can also be set [system-wide][systemd-env-vars].
 
 The easiest way to use this proxy on all of your machines is via a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: docker.service
@@ -321,7 +321,7 @@ systemctl restart docker
 
 The easiest way to use these new ulimits on all of your machines is via a Container Linux Config:
 
-```yaml container-linux-configs
+```yaml
 systemd:
   units:
     - name: docker.service

--- a/os/customizing-sshd.md
+++ b/os/customizing-sshd.md
@@ -9,7 +9,7 @@ As a practical example, when a client fails to connect by not completing the TCP
 In this example we will disable logins for the `root` user, only allow login for the `core` user and disable password based authentication. For more details on what sections can be added to `/etc/ssh/sshd_config` see the [OpenSSH manual][openssh-manual].
 If you're interested in additional security options, Mozilla provides a well-commented example of a [hardened configuration][mozilla-ssh-rec].
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/ssh/sshd_config
@@ -31,7 +31,7 @@ storage:
 
 Flatcar Linux ships with socket-activated SSH daemon by default. The configuration for this can be found at `/usr/lib/systemd/system/sshd.socket`. We're going to override some of the default settings for this in the Container Linux Config provided at boot:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: sshd.socket
@@ -51,7 +51,7 @@ It may be desirable to disable socket-activation for sshd to ensure it will reli
 
 To configure sshd on Flatcar Linux without socket activation, a Container Linux Config file similar to the following may be used:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
   - name: sshd.service

--- a/os/install-debugging-tools.md
+++ b/os/install-debugging-tools.md
@@ -34,7 +34,7 @@ Pulling repository index.example.com/debug
 
 You can also specify this in a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /home/core/.toolboxrc

--- a/os/installing-to-disk.md
+++ b/os/installing-to-disk.md
@@ -74,7 +74,7 @@ After using the [Container Linux Config Transpiler][ct] to produce an Ignition c
 
 A Container Linux Config that specifies an SSH key for the `core` user but doesn't use any other parameters looks like:
 
-```yaml container-linux-config
+```yaml
 passwd:
   users:
     - name: core
@@ -95,7 +95,7 @@ coreos-install -d /dev/sda -C stable -i ~/ignition.json
 
 This example will configure Flatcar Linux components: etcd and flannel. You have to substitute `<PEER_ADDRESS>` to your host's IP or DNS address.
 
-```yaml container-linux-config
+```yaml
 passwd:
   users:
     - name: core

--- a/os/iscsi.md
+++ b/os/iscsi.md
@@ -100,7 +100,7 @@ discovery.sendtargets.auth.password = my_secret_password
 
 ### The Container Linux Config
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: iscsid.service

--- a/os/migrating-to-clcs.md
+++ b/os/migrating-to-clcs.md
@@ -30,7 +30,7 @@ etcd can be configured in a more general way with a Container Linux Config. This
 
 This is done under the etcd section:
 
-```yaml container-linux-config
+```yaml
 etcd:
     version: 3.1.6
 ```
@@ -39,7 +39,7 @@ Omitting the version specification declares that the unit file should use the ve
 
 Configuration options in this section can be provided the same way as they were in a cloud-config, with the exception of dashes (`-`) being replaced with underscores (`_`) in key names.
 
-```yaml container-linux-config:gce
+```yaml
 etcd:
   name:                        "{HOSTNAME}"
   advertise_client_urls:       "{PRIVATE_IPV4}:2379"
@@ -63,7 +63,7 @@ coreos:
 
 The flannel section in a Container Linux Config is used the same way, and a version can optionally be specified for flannel as well.
 
-```yaml container-linux-config
+```yaml
 flannel:
   version:     0.7.0
   etcd_prefix: "/coreos.com/network2"
@@ -83,7 +83,7 @@ coreos:
 
 Locksmith can be configured in the same way under the locksmith section of a Container Linux Config, but some of the accepted options are slightly different. Also the reboot strategy is set in the locksmith section, instead of the update section. Check out the [Container Linux Config schema][ct-config] to see what options are available.
 
-```yaml container-linux-config
+```yaml
 locksmith:
   reboot_strategy: "reboot"
   etcd_endpoints:  "http://example.com:2379"
@@ -104,7 +104,7 @@ coreos:
 
 In the update section in a Container Linux Config the group and server can be configured, but the reboot-strategy option has been moved under the locksmith section.
 
-```yaml container-linux-config
+```yaml
 update:
   group:  "stable"
   server: "https://public.update.core-os.net/v1/update/"
@@ -163,7 +163,7 @@ One big difference in Container Linux Config compared to cloud-configs is that t
 
 _Note: in this example an `[Install]` section has been added so that the unit can be enabled._
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: "docker-redis.service"
@@ -185,7 +185,7 @@ systemd:
 
 Drop-in files can be provided for units in a Container Linux Config just like in a cloud-config.
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: "docker.service"
@@ -198,7 +198,7 @@ systemd:
 
 Existing units can also be enabled without configuration.
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: "etcd-member.service"
@@ -218,7 +218,7 @@ ssh_authorized_keys:
 
 In a Container Linux Config there is no analogous section to `ssh_authorized_keys`, but ssh keys for the core user can be set just as easily using the `passwd.users.*` section:
 
-```yaml container-linux-config
+```yaml
 passwd:
   users:
     - name: core
@@ -238,7 +238,7 @@ hostname: "coreos1"
 
 The Container Linux Config is intentionally more generalized than a cloud-config, and there is no equivalent hostname section understood in a CL Config. Instead, set the hostname by writing it to `/etc/hostname` in a CL Config `storage.files.*` section.
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - filesystem: "root"
@@ -267,7 +267,7 @@ users:
 
 This same information can be added to the Container Linux Config in the `passwd.users.*` section.
 
-```yaml container-linux-config
+```yaml
 passwd:
   users:
     - name:          "elroy"
@@ -295,7 +295,7 @@ write_files:
 
 This can be done in a Container Linux Config with the `storage.files.*` section.
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - filesystem: "root"
@@ -322,7 +322,7 @@ manage_etc_hosts: "localhost"
 
 There is no analogous section in a Container Linux Config, however the `/etc/hosts` file can be written in the `storage.files.*` section.
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - filesystem: "root"

--- a/os/mounting-storage.md
+++ b/os/mounting-storage.md
@@ -5,7 +5,7 @@ Container Linux Configs can be used to format and attach additional filesystems 
 
 Mount units name the source filesystem and target mount point, and optionally the filesystem type. *Systemd* mounts filesystems defined in such units at boot time. The following example formats an [EC2 ephemeral disk](booting-on-ec2.md#instance-storage) and then mounts it at the node's `/media/ephemeral` directory. The mount unit is therefore named `media-ephemeral.mount`.
 
-```yaml container-linux-config
+```yaml
 storage:
   filesystems:
     - name: ephemeral1
@@ -34,7 +34,7 @@ Docker containers can be very large and debugging a build process makes it easy 
 
 We're going to format a device as ext4 and then mount it to `/var/lib/docker`, where Docker stores images. Be sure to hardcode the correct device or look for a device by label:
 
-```yaml container-linux-config
+```yaml
 storage:
   filesystems:
     - name: ephemeral1
@@ -71,7 +71,7 @@ Flatcar Linux uses ext4 + overlayfs to provide a layered filesystem for the root
 
 In this example, we are going to mount a new 25GB btrfs volume file to `/var/lib/docker`. One can verify that Docker is using the btrfs storage driver once the Docker service has started by executing `sudo docker info`. We recommend allocating **no more than 85%** of the available disk space for a btrfs filesystem as journald will also require space on the host filesystem.
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: format-var-lib-docker.service
@@ -106,7 +106,7 @@ Note the declaration of `ConditionPathExists=!/var/lib/docker.btrfs`. Without th
 
 This Container Linux Config excerpt mounts an NFS export onto the Flatcar Linux node's `/var/www`.
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: var-www.mount

--- a/os/network-config-with-networkd.md
+++ b/os/network-config-with-networkd.md
@@ -29,7 +29,7 @@ sudo systemctl restart systemd-networkd
 
 Setting up static networking in your Container Linux Config can be done by writing out the network unit. Be sure to modify the `[Match]` section with the name of your desired interface, and replace the IPs:
 
-```yaml container-linux-config
+```yaml
 networkd:
   units:
     - name: 00-eth0.network
@@ -100,7 +100,7 @@ Destination=172.16.0.0/24
 
 To specify the same route in a Container Linux Config, create the systemd network unit there instead:
 
-```yaml container-linux-config
+```yaml
 networkd:
   units:
     - name: 10-static.network
@@ -130,7 +130,7 @@ Gateway=10.0.1.1
 
 To do the same thing through a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 networkd:
   units:
     - name: 20-multi_ip.network
@@ -175,7 +175,7 @@ journalctl -b -u systemd-networkd
 
 Define a [Drop-In][drop-ins] in a [Container Linux Config][cl-configs]:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: systemd-networkd.service

--- a/os/other-settings.md
+++ b/os/other-settings.md
@@ -10,7 +10,7 @@ echo nf_conntrack > /etc/modules-load.d/nf.conf
 
 Or, using a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/modules-load.d/nf.conf
@@ -31,7 +31,7 @@ Further details can be found in the systemd man pages:
 
 This example Container Linux Config loads the `dummy` network interface module with an option specifying the number of interfaces the module should create when loaded (`numdummies=5`):
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/modprobe.d/dummy.conf
@@ -57,7 +57,7 @@ sysctl --system
 
 Some parameters, such as the conntrack one above, are only available after the module they control has been loaded. To ensure any modules are loaded in advance use `modules-load.d` as described above. A complete Container Linux Config using both would look like:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/modules-load.d/nf.conf
@@ -117,7 +117,7 @@ echo "This machine is dedicated to computing Pi" > /etc/motd.d/pi.conf
 
 Or via a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/motd.d/pi.conf
@@ -138,7 +138,7 @@ echo -e '[Service]\nTTYVTDisallocate=no' > '/etc/systemd/system/getty@.service.d
 
 Or via a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: getty@.service

--- a/os/power-management.md
+++ b/os/power-management.md
@@ -23,7 +23,7 @@ echo "conservative" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor 
 
 This can be configured with a [Container Linux Config][cl-configs] as well:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: cpu-governor.service

--- a/os/provisioning.md
+++ b/os/provisioning.md
@@ -10,20 +10,20 @@ The following examples demonstrate the simplicity of the Container Linux Config 
 
 This extremely simple Container Linux Config will fetch and run the current release of etcd:
 
-```yaml container-linux-config:norender
+```yaml
 etcd:
 ```
 
 Extend the definition to specify the version of etcd to run. The following example will provision a new Flatcar Linux machine to fetch and run the etcd service, version 3.1.6:
 
-```yaml container-linux-config:norender
+```yaml
 etcd:
   version: 3.1.6
 ```
 
 Use variable replacement to configure the etcd service with the provisioning target's public and private IPv4 addresses, making it repeatable across a group of machines.
 
-```yaml container-linux-config:norender
+```yaml
 etcd:
   advertise_client_urls:       http://{PUBLIC_IPV4}:2379
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
@@ -56,7 +56,7 @@ The Container Linux Config Transpiler command line interface, `ct` for short, ca
 
 The following config will configure an etcd cluster using the machine's public and private IP addresses:
 
-```yaml container-linux-config:norender
+```yaml
 etcd:
   advertise_client_urls:       http://{PUBLIC_IPV4}:2379
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380

--- a/os/reading-the-system-log.md
+++ b/os/reading-the-system-log.md
@@ -107,7 +107,7 @@ dmesg | grep systemd-journald
 
 Define a [Drop-In][drop-ins] in a [Container Linux Config][ct-configs]:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: systemd-journald.service

--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -180,7 +180,7 @@ More thorough information about configuring Mesos registry authentication can be
 
 Here is an example of using a Container Linux Config to write the .docker/config.json registry auth configuration file mentioned above to the appropriate path on the Flatcar Linux node:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /home/core/.docker/config.json
@@ -200,7 +200,7 @@ storage:
 
 Container Linux Configs can also download a file from a remote location and verify its integrity with a SHA512 hash:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /home/core/.docker/config.json

--- a/os/root-filesystem-placement.md
+++ b/os/root-filesystem-placement.md
@@ -16,7 +16,7 @@ To place the root filesystem on a RAID array:
 This Container Linux Config creates partitions on `/dev/vdb` and `/dev/vdc` that fill each disk, creates a RAID array named `root_array` from those partitions, and finally creates the root filesystem on the array. To prevent inadvertent booting from the [original root filesystem](https://coreos.com/os/docs/latest/sdk-disk-partitions.html#partition-table), `/dev/vda9` is reformatted with a blank ext4 filesystem labeled `unused`.
 
 **Warning: This will erase both `/dev/vdb` and `/dev/vdc`.**
-```yaml container-linux-config
+```yaml
 storage:
   disks:
     - device: /dev/vdb

--- a/os/scheduling-tasks-with-systemd-timers.md
+++ b/os/scheduling-tasks-with-systemd-timers.md
@@ -43,7 +43,7 @@ Unit=date.service
 
 Here you'll find an example Container Linux Config demonstrating how to install systemd timers:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: date.service

--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -16,7 +16,7 @@ It's important to note that updates are always downloaded to the passive partiti
 
 The reboot strategy can be set with a Container Linux Config:
 
-```yaml container-linux-config
+```yaml
 locksmith:
   reboot_strategy: "etcd-lock"
 ```
@@ -72,7 +72,7 @@ In case when you don't want to install updates onto the passive partition and av
 
 If you wish to disable automatic updates permanently, use can configure this with a Container Linux Config. This example will stop `update-engine`, which executes the updates, and `locksmithd`, which coordinates reboots across the cluster:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: update-engine.service
@@ -86,7 +86,7 @@ systemd:
 Public Internet access is required to contact CoreUpdate and download new versions of Flatcar Linux. If direct access is not available the `update-engine` service may be configured to use a HTTP or SOCKS proxy using curl-compatible environment variables, such as `HTTPS_PROXY` or `ALL_PROXY`.
 See [curl's documentation](http://curl.haxx.se/docs/manpage.html#ALLPROXY) for details.
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: update-engine.service

--- a/os/using-environment-variables-in-systemd-units.md
+++ b/os/using-environment-variables-in-systemd-units.md
@@ -81,7 +81,7 @@ This unit file will run nginx Docker container and bind it to specific IP addres
 
 You can define system wide environment variables using a [Container Linux Config][cl-configs] as explained below:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/systemd/system.conf.d/10-default-env.conf

--- a/os/using-systemd-and-udev-rules.md
+++ b/os/using-systemd-and-udev-rules.md
@@ -41,7 +41,7 @@ That rule means that udev will trigger `device-attach.service` systemd unit on a
 
 To use the unit and udev rule with a Container Linux Config, modify this example as needed:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /etc/udev/rules.d/01-block.rules

--- a/os/using-systemd-drop-in-units.md
+++ b/os/using-systemd-drop-in-units.md
@@ -92,7 +92,7 @@ RestartSec=60s
 
 Container Linux Config example:
 
-```yaml container-linux-config
+```yaml
 systemd:
   units:
     - name: fleet.service

--- a/quay-enterprise/configure-machines.md
+++ b/quay-enterprise/configure-machines.md
@@ -73,7 +73,7 @@ To use a specific pull secret as the default in a specific namespace, you can cr
 
 A snippet to configure the credentials via `files` in a Container Linux Config looks like:
 
-```yaml container-linux-config
+```yaml
 storage:
   files:
     - path: /root/.dockercfg


### PR DESCRIPTION
CoreOS uses the custom tags with a generator extension to give users the
option to see both *) the yaml source and the **) transpiled json
output. Since we don't have such an extension at hands, only show the
yaml for the time being.

Used command for future reference:

```
git grep --name '```yaml container-linux-config' | \
  xargs -r sed -i -E \
  's/(.*```yaml) container-linux-config.*/\1/g'
```