### PR TITLE
Fix the link to the image signing key

### DIFF
--- a/os/verify-images.md
+++ b/os/verify-images.md
@@ -2,7 +2,7 @@
 
 Kinvolk publishes new Flatcar Linux images for each release across a variety of platforms and hosting providers. Each channel has its own set of images ([stable], [beta], [alpha]) that are posted to our storage site. Along with each image, a signature is generated from the [Flatcar Linux Image Signing Key][signing-key] and posted.
 
-[signing-key]: https://coreos.com/security/image-signing-key
+[signing-key]: https://www.flatcar-linux.org/security/image-signing-key/
 [stable]: https://stable.release.flatcar-linux.net/amd64-usr/current/
 [beta]: https://beta.release.flatcar-linux.net/amd64-usr/current/
 [alpha]: https://alpha.release.flatcar-linux.net/amd64-usr/current/


### PR DESCRIPTION
The image signing key link was pointing to the CoreOS signing key. This fixes that.