### PR TITLE
os/flatcar-update-from-container-linux: clarify user_data path

### DIFF
--- a/os/flatcar-update-from-container-linux.md
+++ b/os/flatcar-update-from-container-linux.md
@@ -32,6 +32,8 @@ Then, you need to edit `/usr/share/coreos/release` and replace the value of `COR
 COREOS_RELEASE_VERSION=0.0.0
 ```
 
+**NOTE:** In bare metal installations, the path where `user_data` is expected changes from `/var/lib/coreos-install/user_data` to `/var/lib/flatcar-install/user-data`. Make sure you place your `user_data` in the new path.
+
 After that, restart the update service so it rescans the edited configuration and initiates an update.
 The system will reboot into Flatcar Linux:
 


### PR DESCRIPTION
In bare metal installations we change the path where `user_data` is
expected, add a note explaining that for updates from Container Linux.

Fixes flatcar-linux/Flatcar#4