### PR TITLE
os: replace coreos with flatcar

### DIFF
--- a/os/cluster-architectures.md
+++ b/os/cluster-architectures.md
@@ -180,11 +180,6 @@ etcd:
   initial_advertise_peer_urls: http://10.0.0.101:2380
   listen_client_urls: http://0.0.0.0:2379
   listen_peer_urls: http://10.0.0.101:2380
-update:
-  # CoreUpdate group ID for "Production Central Services"
-  # Use "stable", "beta", or "alpha" for non-subscribers.
-  group: 9e98ecae-4623-48c1-9679-423549c44da6
-  server: https://customer.update.core-os.net/v1/update/
 systemd:
   units:
     - name: etcd-member.service
@@ -200,21 +195,6 @@ networkd:
         DNS=1.2.3.4
         Address=10.0.0.101/24
         Gateway=10.0.0.1
-```
-
-### Configuration for worker role
-
-The worker roles will use DHCP and should be easy to add capacity or autoscaling.
-
-Here's an example CL Config for a worker which specifies an update channel:
-
-```yaml
-update:
-  # CoreUpdate group ID for "Production Central Services"
-  # Use "stable", "beta", or "alpha" for non-subscribers.
-  group: 9e98ecae-4623-48c1-9679-423549c44da6
-  # Non-subscribers should use server: "https://public.update.core-os.net/v1/update/"
-  server: https://customer.update.core-os.net/v1/update/
 ```
 
 [ct-download]: https://github.com/coreos/container-linux-config-transpiler/releases

--- a/os/kernel-modules.md
+++ b/os/kernel-modules.md
@@ -43,7 +43,7 @@ Read system configuration files to determine the URL of the development containe
 ```sh
 . /usr/share/coreos/release
 . /usr/share/coreos/update.conf
-url="http://${GROUP:-stable}.release.core-os.net/$COREOS_RELEASE_BOARD/$COREOS_RELEASE_VERSION/coreos_developer_container.bin.bz2"
+url="http://${GROUP:-stable}.release.flatcar-linux.net/$COREOS_RELEASE_BOARD/$COREOS_RELEASE_VERSION/flatcar_developer_container.bin.bz2"
 ```
 
 Download, decompress, and verify the development container image.
@@ -51,7 +51,7 @@ Download, decompress, and verify the development container image.
 ```sh
 gpg2 --recv-keys 04127D0BFABEC8871FFB2CCE50E0885593D2DCB4  # Fetch the buildbot key if neccesary.
 curl -L "$url" |
-    tee >(bzip2 -d > coreos_developer_container.bin) |
+    tee >(bzip2 -d > flatcar_developer_container.bin) |
     gpg2 --verify <(curl -Ls "$url.sig") -
 ```
 
@@ -60,7 +60,7 @@ Start the development container with the host's writable modules directory mount
 ```sh
 sudo systemd-nspawn \
     --bind=/lib/modules \
-    --image=coreos_developer_container.bin
+    --image=flatcar_developer_container.bin
 ```
 
 Now, inside the container, fetch the Flatcar Linux package definitions, then download and prepare the Linux kernel source for building external modules.

--- a/os/migrating-to-clcs.md
+++ b/os/migrating-to-clcs.md
@@ -99,7 +99,7 @@ coreos:
   update:
     reboot-strategy: "etcd-lock"
     group:           "stable"
-    server:          "https://public.update.core-os.net/v1/update/"
+    server:          "https://public.update.flatcar-linux.net/v1/update/"
 ```
 
 In the update section in a Container Linux Config the group and server can be configured, but the reboot-strategy option has been moved under the locksmith section.
@@ -107,7 +107,7 @@ In the update section in a Container Linux Config the group and server can be co
 ```yaml
 update:
   group:  "stable"
-  server: "https://public.update.core-os.net/v1/update/"
+  server: "https://public.update.flatcar-linux.net/v1/update/"
 ```
 
 ### units

--- a/os/notes-for-distributors.md
+++ b/os/notes-for-distributors.md
@@ -2,27 +2,27 @@
 
 ## Importing images
 
-Images of Flatcar Linux alpha releases are hosted at [`https://alpha.release.core-os.net/amd64-usr/`][alpha-bucket]. There are directories for releases by version as well as `current` with a copy of the latest version. Similarly, beta releases can be found at [`https://beta.release.core-os.net/amd64-usr/`][beta-bucket] and stable releases at [`https://stable.release.core-os.net/amd64-usr/`][stable-bucket].
+Images of Flatcar Linux alpha releases are hosted at [`https://alpha.release.flatcar-linux.net/amd64-usr/`][alpha-bucket]. There are directories for releases by version as well as `current` with a copy of the latest version. Similarly, beta releases can be found at [`https://beta.release.flatcar-linux.net/amd64-usr/`][beta-bucket] and stable releases at [`https://stable.release.flatcar-linux.net/amd64-usr/`][stable-bucket].
 
 Each directory has a `version.txt` file containing version information for the files in that directory. If you are importing images for use inside your environment it is recommended that you fetch `version.txt` from the `current` directory and use its contents to compute the path to the other artifacts. For example, to download the alpha OpenStack version of Flatcar Linux:
 
-1. Download `https://alpha.release.core-os.net/amd64-usr/current/version.txt`.
+1. Download `https://alpha.release.flatcar-linux.net/amd64-usr/current/version.txt`.
 2. Parse `version.txt` to obtain the value of `COREOS_VERSION_ID`, for example `1576.1.0`.
-3. Download `https://alpha.release.core-os.net/amd64-usr/1576.1.0/flatcar_production_openstack_image.img.bz2`.
+3. Download `https://alpha.release.flatcar-linux.net/amd64-usr/1576.1.0/flatcar_production_openstack_image.img.bz2`.
 
 It is recommended that you also verify files using the [Flatcar Linux Image Signing Key][signing-key]. The GPG signature for each image is a detached `.sig` file that must be passed to `gpg --verify`. For example:
 
 ```sh
-wget https://alpha.release.core-os.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
-wget https://alpha.release.core-os.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2.sig
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2.sig
 gpg --verify flatcar_production_openstack_image.img.bz2.sig
 ```
 
 The signing key is rotated annually. We will announce upcoming rotations of the signing key on the [user mailing list][flatcar-user].
 
-[alpha-bucket]: https://alpha.release.core-os.net/amd64-usr/
-[beta-bucket]: https://beta.release.core-os.net/amd64-usr/
-[stable-bucket]: https://stable.release.core-os.net/amd64-usr/
+[alpha-bucket]: https://alpha.release.flatcar-linux.net/amd64-usr/
+[beta-bucket]: https://beta.release.flatcar-linux.net/amd64-usr/
+[stable-bucket]: https://stable.release.flatcar-linux.net/amd64-usr/
 [signing-key]: https://coreos.com/security/image-signing-key
 [flatcar-user]: https://groups.google.com/forum/#!forum/flatcar-linux-user
 

--- a/os/sdk-building-development-images.md
+++ b/os/sdk-building-development-images.md
@@ -23,7 +23,7 @@ gmerge coreos-base/update_engine
 If you want to test that an image you built can successfully upgrade a running VM you can use devserver. To specify the version to upgrade to you can use the `--image` argument. This should be a newer build than the VM is currently running, otherwise devserver will answer "no update" to any requests. Here is an example using the default value:
 
 ```sh
-start_devserver --image ../build/images/amd64-usr/latest/coreos_developer_image.bin
+start_devserver --image ../build/images/amd64-usr/latest/flatcar_developer_image.bin
 ```
 
 On the target VM ensure that the `SERVER` setting in `/etc/coreos/update.conf` points to your workstation, for example:

--- a/os/sdk-building-production-images.md
+++ b/os/sdk-building-production-images.md
@@ -62,23 +62,6 @@ Note: Add `COREOS_OFFICIAL=1` here if you are making a real release. That will c
 
 The generated production image is bootable as-is by qemu but for a larger ROOT partition or VMware images use `image_to_vm.sh` as described in the final output of `build_image`.
 
-## Pushing updates into CoreUpdate
-
-The automated build host does not have access to production signing keys so the final signing and push to roller must be done elsewhere. The `flatcar_production_update.zip` archive provides the tools required to do this so a full SDK setup is not required. This does require gsutil to be installed and configured. An update payload signed by the insecure development keys is generated automatically as `flatcar_production_update.gz` and `flatcar_production_update.meta`. If needed the raw filesystem image used to generate the payload is `flatcar_production_update.bin.bz2`. As an example, to publish the insecurely signed payload:
-
-```sh
-URL=gs://builds.release.core-os.net/alpha/amd64-usr/321.0.0
-cd $(mktemp -d)
-gsutil -m cp $URL/flatcar_production_update* ./
-gpg --verify flatcar_production_update.zip.sig
-gpg --verify flatcar_production_update.gz.sig
-gpg --verify flatcar_production_update.meta.sig
-unzip flatcar_production_update.zip
- ./core_roller_upload --user <you>@flatcar-linux.org --api_key <yourkey>
-```
-
-Note: prefixing the command with a space will avoid recording your API key in your bash history if `$HISTCONTROL` is `ignorespace` or `ignoreboth`.
-
 ## Tips and Tricks
 
 We've compiled a [list of tips and tricks](sdk-tips-and-tricks.md) that can make working with the SDK a bit easier.


### PR DESCRIPTION
There are still many places where coreos-related strings are used. Replace only relevant strings with flatcar-related strings.

For example, `customer.*` sites are not available for flatcar, so they are excluded.