### PR TITLE
set the specific branch flatcar-master for clct in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "container-linux-config-transpiler"]
 	path = container-linux-config-transpiler
 	url = git@github.com:kinvolk/container-linux-config-transpiler.git
+	branch = flatcar-master


### PR DESCRIPTION
The [flatcar-website-docs](https://github.com/kinvolk/flatcar-website-docs) repo has a submodule [docs](https://github.com/kinvolk/docs), which has again another submodule
[container-linux-config-transpiler](https://github.com/kinvolk/container-linux-config-transpiler).

While the `docs` repo has only the master branch, the `c-l-c-t` has its own branch `flatcar-master`. When `flatcar-website-docs` updates submodules recursively, it should actually get the `flatcar-master` branch of `c-l-c-t`, not the `master` branch. That's why `git submodule
update --recursive --remote` resulted in an inconsistent state of `c-l-c-t` repo.

Let's specify the branch to `flatcar-master`, to make the specific branch automatically available under `flatcar-website-docs`.