### PR TITLE
os: fix how to download cork binary file

### DIFF
--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -69,7 +69,7 @@ Next, use the cork utility to create a project directory. This will hold all of 
 ```sh
 mkdir flatcar-sdk
 cd flatcar-sdk
-cork create --manifest-branch=flatcar-master --manifest-url=https://github.com/flatcar-linux/manifest
+cork create
 cork enter
 ```
 


### PR DESCRIPTION
The existing cork binary provided by upstream, could not be used by Flatcar SDK, because it checked for coreos-specific variables. So let's use the cork v0.11.2, built from flatcar-master.

For now there's no GPG signature for the cork binary. Still we need to figure out how to generate the GPG signature to be uploaded to the cork release v0.11.2.