### PR TITLE
os: describe the edge channel in the installation docs

### DIFF
--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -11,6 +11,7 @@ Flatcar Linux is designed to be updated automatically with different schedules p
     <li class="active"><a href="#stable" data-toggle="tab">Stable Channel</a></li>
     <li><a href="#beta" data-toggle="tab">Beta Channel</a></li>
     <li><a href="#alpha" data-toggle="tab">Alpha Channel</a></li>
+    <li><a href="#edge" data-toggle="tab">Edge Channel</a></li>
   </ul>
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha">
@@ -72,6 +73,37 @@ Flatcar Linux is designed to be updated automatically with different schedules p
           <td class="rowspan-padding"><a href="http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/">HVM</a></td>
           <td><a href="https://console.{{ region_domain }}/ec2/home?region={{ region.name }}#launchAmi={{ region.hvm }}">{{ region.hvm }}</a></td>
           <td><a href="https://console.{{ region_domain }}/cloudformation/home?region={{ region.name }}#cstack=sn%7EFlatcar-beta%7Cturl%7Ehttps:%2F%2Fflatcar-prod-ami-import-eu-central-1.s3.amazonaws.com%2Fdist%2Faws%2Fflatcar-beta-hvm.template" target="_blank"><img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" alt="Launch Stack"/></a></td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="tab-pane" id="edge">
+      <div class="channel-info">
+        <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Linux {{site.edge-channel}}.</p>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>EC2 Region</th>
+            <th>AMI Type</th>
+            <th>AMI ID</th>
+            <th>CloudFormation</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for region in site.data.edge-channel.amis %}
+        {% capture region_domain %}{% if region.name == 'us-gov-west-1' %}amazonaws-us-gov.com{% elsif region.name == 'cn-north-1' %}amazonaws.cn{% else %}aws.amazon.com{% endif %}{% endcapture %}
+        <tr>
+          <td rowspan="2">{{ region.name }}</td>
+          <td class="dashed"><a href="http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/">PV</a></td>
+          <td class="dashed"><a href="https://console.{{ region_domain }}/ec2/home?region={{ region.name }}#launchAmi={{ region.pv }}">{{ region.pv }}</a></td>
+          <td class="dashed"><a href="https://console.{{ region_domain }}/cloudformation/home?region={{ region.name }}#cstack=sn%7EFlatcar-edge%7Cturl%7Ehttps:%2F%2Fflatcar-prod-ami-import-eu-central-1.s3.amazonaws.com%2Fdist%2Faws%2Fflatcar-edge-pv.template" target="_blank"><img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" alt="Launch Stack"/></a></td>
+        </tr>
+        <tr>
+          <td class="rowspan-padding"><a href="http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/">HVM</a></td>
+          <td><a href="https://console.{{ region_domain }}/ec2/home?region={{ region.name }}#launchAmi={{ region.hvm }}">{{ region.hvm }}</a></td>
+          <td><a href="https://console.{{ region_domain }}/cloudformation/home?region={{ region.name }}#cstack=sn%7EFlatcar-edge%7Cturl%7Ehttps:%2F%2Fflatcar-prod-ami-import-eu-central-1.s3.amazonaws.com%2Fdist%2Faws%2Fflatcar-edge-hvm.template" target="_blank"><img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" alt="Launch Stack"/></a></td>
         </tr>
         {% endfor %}
         </tbody>

--- a/os/booting-with-ipxe.md
+++ b/os/booting-with-ipxe.md
@@ -35,6 +35,7 @@ Flatcar Linux is designed to be updated automatically with different schedules p
     <li class="active"><a href="#stable-create" data-toggle="tab">Stable Channel</a></li>
     <li><a href="#beta-create" data-toggle="tab">Beta Channel</a></li>
     <li><a href="#alpha-create" data-toggle="tab">Alpha Channel</a></li>
+    <li><a href="#edge-create" data-toggle="tab">Edge Channel</a></li>
   </ul>
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
@@ -55,6 +56,17 @@ boot</pre>
 #!ipxe
 
 set base-url http://beta.release.flatcar-linux.net/amd64-usr/current
+kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 flatcar.config.url=https://example.com/pxe-config.ign
+initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
+boot</pre>
+    </div>
+    <div class="tab-pane" id="edge-create">
+      <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Linux {{site.edge-channel}}.</p>
+      <p>iPXE downloads a boot script from a publicly available URL. You will need to host this URL somewhere public and replace the example SSH key with your own. You can also run a <a href="https://github.com/kelseyhightower/coreos-ipxe-server">custom iPXE server</a>.</p>
+      <pre>
+#!ipxe
+
+set base-url http://edge.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 flatcar.config.url=https://example.com/pxe-config.ign
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot</pre>

--- a/os/booting-with-iso.md
+++ b/os/booting-with-iso.md
@@ -7,6 +7,7 @@ The latest Flatcar Linux ISOs can be downloaded from the image storage site:
     <li class="active"><a href="#stable" data-toggle="tab">Stable Channel</a></li>
     <li><a href="#beta" data-toggle="tab">Beta Channel</a></li>
     <li><a href="#alpha" data-toggle="tab">Alpha Channel</a></li>
+    <li><a href="#edge" data-toggle="tab">Edge Channel</a></li>
   </ul>
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha">
@@ -24,6 +25,15 @@ The latest Flatcar Linux ISOs can be downloaded from the image storage site:
       </div>
       <a href="https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_iso_image.iso" class="btn btn-primary">Download Beta ISO</a>
       <a href="https://beta.release.flatcar-linux.net/amd64-usr/current/" class="btn btn-default">Browse Storage Site</a>
+      <br/><br/>
+      <p>All of the files necessary to verify the image can be found on the storage site.</p>
+    </div>
+    <div class="tab-pane" id="edge">
+      <div class="channel-info">
+        <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Linux {{site.edge-channel}}.</p>
+      </div>
+      <a href="https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_iso_image.iso" class="btn btn-primary">Download Edge ISO</a>
+      <a href="https://edge.release.flatcar-linux.net/amd64-usr/current/" class="btn btn-default">Browse Storage Site</a>
       <br/><br/>
       <p>All of the files necessary to verify the image can be found on the storage site.</p>
     </div>

--- a/os/booting-with-libvirt.md
+++ b/os/booting-with-libvirt.md
@@ -22,6 +22,7 @@ Flatcar Linux is designed to be updated automatically with different schedules p
     <li class="active"><a href="#stable-create" data-toggle="tab">Stable Channel</a></li>
     <li><a href="#beta-create" data-toggle="tab">Beta Channel</a></li>
     <li><a href="#alpha-create" data-toggle="tab">Alpha Channel</a></li>
+    <li><a href="#edge-create" data-toggle="tab">Edge Channel</a></li>
   </ul>
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
@@ -41,6 +42,16 @@ bunzip2 flatcar_production_qemu_image.img.bz2</pre>
 mkdir -p /var/lib/libvirt/images/flatcar-linux
 cd /var/lib/libvirt/images/flatcar-linux
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2{,.sig}
+gpg --verify flatcar_production_qemu_image.img.bz2.sig
+bunzip2 flatcar_production_qemu_image.img.bz2</pre>
+    </div>
+    <div class="tab-pane" id="edge-create">
+      <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Linux {{site.edge-channel}}.</p>
+      <p>We start by downloading the most recent disk image:</p>
+      <pre>
+mkdir -p /var/lib/libvirt/images/flatcar-linux
+cd /var/lib/libvirt/images/flatcar-linux
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2{,.sig}
 gpg --verify flatcar_production_qemu_image.img.bz2.sig
 bunzip2 flatcar_production_qemu_image.img.bz2</pre>
     </div>

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -68,6 +68,7 @@ PXE booted machines cannot currently update themselves when new versions are rel
     <li class="active"><a href="#stable-create" data-toggle="tab">Stable Channel</a></li>
     <li><a href="#beta-create" data-toggle="tab">Beta Channel</a></li>
     <li><a href="#alpha-create" data-toggle="tab">Alpha Channel</a></li>
+    <li><a href="#edge-create" data-toggle="tab">Edge Channel</a></li>
   </ul>
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
@@ -94,6 +95,20 @@ wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz.sig
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz.sig
+gpg --verify flatcar_production_pxe.vmlinuz.sig
+gpg --verify flatcar_production_pxe_image.cpio.gz.sig
+      </pre>
+    </div>
+    <div class="tab-pane" id="edge-create">
+      <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Linux {{site.edge-channel}}.</p>
+      <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
+      <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="notes-for-distributors.md#importing-images">verify the downloaded files</a>.</p>
+      <pre>
+cd /var/lib/tftpboot
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz.sig
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz.sig
 gpg --verify flatcar_production_pxe.vmlinuz.sig
 gpg --verify flatcar_production_pxe_image.cpio.gz.sig
       </pre>

--- a/os/booting-with-qemu.md
+++ b/os/booting-with-qemu.md
@@ -68,6 +68,7 @@ Flatcar Linux is designed to be updated automatically with different schedules p
     <li class="active"><a href="#stable" data-toggle="tab">Stable Channel</a></li>
     <li><a href="#beta" data-toggle="tab">Beta Channel</a></li>
     <li><a href="#alpha" data-toggle="tab">Alpha Channel</a></li>
+    <li><a href="#edge" data-toggle="tab">Edge Channel</a></li>
   </ul>
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane active" id="stable">
@@ -113,6 +114,22 @@ wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2.sig
+gpg --verify flatcar_production_qemu.sh.sig
+gpg --verify flatcar_production_qemu_image.img.bz2.sig
+bzip2 -d flatcar_production_qemu_image.img.bz2
+chmod +x flatcar_production_qemu.sh</pre>
+    </div>
+    <div class="tab-pane" id="edge">
+      <div class="channel-info">
+        <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Linux {{site.edge-channel}}.</p>
+      </div>
+      <p>There are two files you need: the disk image (provided in qcow2
+      format) and the wrapper shell script to start QEMU.</p>
+      <pre>mkdir flatcar; cd flatcar
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
+wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2.sig
 gpg --verify flatcar_production_qemu.sh.sig
 gpg --verify flatcar_production_qemu_image.img.bz2.sig
 bzip2 -d flatcar_production_qemu_image.img.bz2

--- a/os/installing-to-disk.md
+++ b/os/installing-to-disk.md
@@ -29,6 +29,7 @@ Flatcar Linux is designed to be [updated automatically](https://coreos.com/why/#
     <li class="active"><a href="#stable-create" data-toggle="tab">Stable Channel</a></li>
     <li><a href="#beta-create" data-toggle="tab">Beta Channel</a></li>
     <li><a href="#alpha-create" data-toggle="tab">Alpha Channel</a></li>
+    <li><a href="#edge-create" data-toggle="tab">Edge Channel</a></li>
   </ul>
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
@@ -40,6 +41,11 @@ Flatcar Linux is designed to be [updated automatically](https://coreos.com/why/#
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Linux {{site.beta-channel}}.</p>
       <p>If you want to ensure you are installing the latest beta version, use the <code>-C</code> option:</p>
       <pre>flatcar-install -d /dev/sda -C beta</pre>
+    </div>
+    <div class="tab-pane" id="edge-create">
+      <p>The Edge channel includes bleeding-edge features with the newest versions of the Linux kernel, systemd and other core packages. Can be highly unstable. The current version is Flatcar Linux {{site.edge-channel}}.</p>
+      <p>If you want to ensure you are installing the latest edge version, use the <code>-C</code> option:</p>
+      <pre>flatcar-install -d /dev/sda -C edge</pre>
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Linux {{site.stable-channel}}.</p>

--- a/os/notes-for-distributors.md
+++ b/os/notes-for-distributors.md
@@ -2,7 +2,7 @@
 
 ## Importing images
 
-Images of Flatcar Linux alpha releases are hosted at [`https://alpha.release.flatcar-linux.net/amd64-usr/`][alpha-bucket]. There are directories for releases by version as well as `current` with a copy of the latest version. Similarly, beta releases can be found at [`https://beta.release.flatcar-linux.net/amd64-usr/`][beta-bucket] and stable releases at [`https://stable.release.flatcar-linux.net/amd64-usr/`][stable-bucket].
+Images of Flatcar Linux alpha releases are hosted at [`https://alpha.release.flatcar-linux.net/amd64-usr/`][alpha-bucket]. There are directories for releases by version as well as `current` with a copy of the latest version. Similarly, beta releases can be found at [`https://beta.release.flatcar-linux.net/amd64-usr/`][beta-bucket], edge releases at [`https://edge.release.flatcar-linux.net/amd64-usr/`][edge-bucket], and stable releases at [`https://stable.release.flatcar-linux.net/amd64-usr/`][stable-bucket].
 
 Each directory has a `version.txt` file containing version information for the files in that directory. If you are importing images for use inside your environment it is recommended that you fetch `version.txt` from the `current` directory and use its contents to compute the path to the other artifacts. For example, to download the alpha OpenStack version of Flatcar Linux:
 
@@ -22,6 +22,7 @@ The signing key is rotated annually. We will announce upcoming rotations of the 
 
 [alpha-bucket]: https://alpha.release.flatcar-linux.net/amd64-usr/
 [beta-bucket]: https://beta.release.flatcar-linux.net/amd64-usr/
+[edge-bucket]: https://edge.release.flatcar-linux.net/amd64-usr/
 [stable-bucket]: https://stable.release.flatcar-linux.net/amd64-usr/
 [signing-key]: https://coreos.com/security/image-signing-key
 [flatcar-user]: https://groups.google.com/forum/#!forum/flatcar-linux-user

--- a/os/verify-images.md
+++ b/os/verify-images.md
@@ -1,11 +1,12 @@
 # Verify Flatcar Linux images with GPG
 
-Kinvolk publishes new Flatcar Linux images for each release across a variety of platforms and hosting providers. Each channel has its own set of images ([stable], [beta], [alpha]) that are posted to our storage site. Along with each image, a signature is generated from the [Flatcar Linux Image Signing Key][signing-key] and posted.
+Kinvolk publishes new Flatcar Linux images for each release across a variety of platforms and hosting providers. Each channel has its own set of images ([stable], [beta], [alpha], [edge]) that are posted to our storage site. Along with each image, a signature is generated from the [Flatcar Linux Image Signing Key][signing-key] and posted.
 
 [signing-key]: https://www.flatcar-linux.org/security/image-signing-key/
 [stable]: https://stable.release.flatcar-linux.net/amd64-usr/current/
 [beta]: https://beta.release.flatcar-linux.net/amd64-usr/current/
 [alpha]: https://alpha.release.flatcar-linux.net/amd64-usr/current/
+[edge]: https://edge.release.flatcar-linux.net/amd64-usr/current/
 
 After downloading your image, you should verify it with `gpg` tool. First, download the image signing key:
 


### PR DESCRIPTION
Add descriptions on the edge channel in the os installation docs.

Note: it's touching only the important parts, but not all the docs for the cloud providers.