### PR TITLE
os: bump cork to 0.13.2

### DIFF
--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -36,8 +36,8 @@ The `cork` utility, included in the Flatcar Container Linux [mantle](https://git
 First, download the cork utility and verify it with the signature:
 
 ```sh
-curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v0.13.1/cork-0.13.1-amd64
-curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v0.13.1/cork-0.13.1-amd64.sig
+curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v0.13.2/cork-0.13.2-amd64
+curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v0.13.2/cork-0.13.2-amd64.sig
 gpg --receive-keys 84C8E771C0DF83DFBFCAAAF03ADA89DEC2507883
 gpg --verify cork.sig cork
 ```


### PR DESCRIPTION
Update cork version to 0.13.2 in the Flatcar SDK document.