### PR TITLE
Give more guidance on renaming OEM variables

### DIFF
--- a/os/migrate-from-container-linux.md
+++ b/os/migrate-from-container-linux.md
@@ -2,7 +2,7 @@
 
 While Flatcar is compatible with CoreOS Container Linux there are some naming differences you need to be aware of.
 
-**NOTE:** See [Updating from CoreOS Container Linux](https://docs.flatcar-linux.org/os/update-from-container-linux/)
+**NOTE:** See [Updating from CoreOS Container Linux](update-from-container-linux.md)
 for additional information on updating an existing cluster.
 
 ## Installation
@@ -22,6 +22,15 @@ will only support `ignition.config.url`.
 
 Instead of providing the `coreos.oem.id=NAME` argument via the boot loader you need to provide `flatcar.oem.id=NAME`.
 (A change to the more generic name `ignition.platform.id` was done upstream by the Afterburn project but is not part of Container Linux yet.)
+
+**Recover from or prevent errors with missing OEM settings (e.g., `coreos-metadata-sshkeys@core.service`):** While future releases will handle both `coreos.oem` and `flatcar.oem` names, all current releases still require `flatcar.oem.…`.
+Change the variables in the file `/usr/share/oem/grub.cfg` when you update from CoreOS Container Linux:
+
+```
+# GRUB settings
+set oem_id="myoemvalue"
+set linux_append="$linux flatcar.oem.id=myoemvalue"
+```
 
 ## Ignition configuration with QEMU
 

--- a/os/update-from-container-linux.md
+++ b/os/update-from-container-linux.md
@@ -2,7 +2,7 @@
 
 If you already have CoreOS Container Linux clusters and can't or don't want to freshly install Flatcar Container Linux, you can update to Flatcar Container Linux directly from CoreOS Container Linux by performing the following steps.
 
-**NOTE:** General differences when [migrating from CoreOS Container Linux](https://docs.flatcar-linux.org/os/migrate-from-container-linux/) also apply.
+**NOTE:** General differences when [migrating from CoreOS Container Linux](migrate-from-container-linux.md) also apply.
 
 At [the end of the section](#all-steps-in-one-script) you can find the [update-to-flatcar.sh](/update-to-flatcar.sh) script that does all steps for you.
 
@@ -69,6 +69,7 @@ Done, please reboot now
 core@host ~ $ sudo systemctl reboot
 ```
 
+**Before you reboot, check that you migrated the variable names as written in [Migrating from CoreOS Container Linux](migrate-from-container-linux.md).**
 
 
 ## Going back to CoreOS Container Linux


### PR DESCRIPTION
We should warn again that before rebooting any OEM
variables need to be renamed for now.
Tell where they are found.