### PR TITLE
index.md: style fix: add new line

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,6 +65,7 @@ Flatcar Container Linux supports all of the popular methods for running containe
 Docker
 --------------
 [Getting started with Docker][docker]
+
 [Customizing Docker][customizing-docker]
 
 


### PR DESCRIPTION
My previous patch makes the two links about Docker documentation appear
on the same line. It looks better on separate lines.