### PR TITLE
container-runtimes: simpler and future-proof containerd customization

### DIFF
--- a/docs/container-runtimes/customizing-docker.md
+++ b/docs/container-runtimes/customizing-docker.md
@@ -19,9 +19,8 @@ Then create a `/etc/systemd/system/containerd.service.d/10-use-custom-config.con
 
 ```ini
 [Service]
-Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/containerd
 ```
 
 On a running system, execute `systemctl daemon-reload ; systemctl restart containerd` for it to take effect.


### PR DESCRIPTION
The existing /usr/bin/containerd torcx wrapper already takes care of
using the right binaries. The torcx path in the customization
instructions can be avoided which helps to make this more future-proof
when torcx is not used. Also, the default config is under /etc and does
not need to be specified (the env var is custom to torcx, too).

Do not set up the env var nor specify the config path, and stop
hardcoding the torcx binary path.


## How to use/Testing done

I created a config in `/etc` and checked that it gets taken up and that the containerd service works.