### PR TITLE
add `gawk` to the requirements for hetzner

### DIFF
--- a/docs/installing/cloud/hetzner.md
+++ b/docs/installing/cloud/hetzner.md
@@ -23,6 +23,7 @@ Select any OS like Debian when you create the instance but boot into the `linux6
 Connect via SSH and download and run the `flatcar-install` script:
 
 ```sh
+apt -y install gawk
 curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 https://raw.githubusercontent.com/kinvolk/init/flatcar-master/bin/flatcar-install
 chmod +x flatcar-install
 ./flatcar-install -s -i ignition.json # optional: you may provide a Ignition Config as file, it should contain your SSH key


### PR DESCRIPTION
# [Title: describe the change in one sentence]

The Hetzner Rescue System runs on Debian 11 but seems to be missing `gawk` which is required by the flatcar installer.

## How to use

Follow the instructions

## Testing done

* Tested the config as-is in a clean Hetzner Rescue system, which showed an error about missing `gawk`
* Then added `gawk` and the process worked fine
