### PR TITLE
Add example for whole disk as swap

### DIFF
--- a/docs/setup/storage/adding-swap.md
+++ b/docs/setup/storage/adding-swap.md
@@ -126,3 +126,41 @@ systemd:
         ExecStart=/usr/sbin/mkswap /var/vm/swapfile1
         RemainAfterExit=true
 ```
+
+## Using a dedicated swap disk
+
+The following Container Linux config sets up `/dev/sdb` to be used as swap:
+
+```yaml
+storage:
+  disks: 
+    - device: /dev/sdb 
+      wipe_table: true 
+      partitions: 
+        - label: swap
+          type_guid: 0657FD6D-A4AB-43C4-84E5-0933C84B4F4F
+  filesystems:
+    - name: swap
+      mount:
+        device: /dev/disk/by-partlabel/swap
+        format: swap
+        wipe_filesystem: true
+        label: swap
+systemd:
+  units:
+    - name: dev-disk-by\x2dpartlabel-swap.swap
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Swap
+        [Swap]
+        What=/dev/disk/by-partlabel/swap
+        [Install]
+        WantedBy=multi-user.target
+```
+
+NB the systemd unit name is created by
+`systemd-escape -p /dev/disk/by-partlabel/swap` as systemd uses - as the
+path separator meaning that paths containing - have to be escaped. This
+leads to a file `'dev-disk-by\x2dpartlabel-swap.swap'` being created in
+`/etc/systemd/system`


### PR DESCRIPTION
# Add example for whole disk as swap

Container Linux config sample with sections for disks, filesystems and the systemd unit to mount swap.

## How to use

Create an ignition file including the transpiled content from the example.

Start a VM with an additional disk that will be mounted as /dev/sdb on first boot.

## Testing done

This has been tested on GCE using this script to start VMs:

```bash
#!/bin/bash
VMNAME=test-123
ZONE=us-central1-a
PROJECT=myproject
gcloud compute instances create "$VMNAME" --project="$PROJECT" \
--zone "$ZONE" --machine-type e2-standard-2 \
--network-interface=network-tier=PREMIUM,subnet="$PROJECT"vpc-01 \
--create-disk=auto-delete=yes,boot=yes,device-name="$VMNAME"-boot,image-project=kinvolk-public,image-family=flatcar-stable,mode=rw,size=100,type=projects/"$PROJECT"/zones/"$ZONE"/diskTypes/pd-standard \
--create-disk=device-name="$VMNAME"-swap,mode=rw,name="$VMNAME"-swap,size=32,type=projects/"$PROJECT"/zones/"$ZONE"/diskTypes/pd-ssd \
--metadata-from-file user-data=config_with_swap.ign 
```
