### PR TITLE
config-transpiler/dynamic-data.md: correct custom platform guide

### DIFF
--- a/docs/installing/cloud/vmware.md
+++ b/docs/installing/cloud/vmware.md
@@ -168,6 +168,8 @@ systemd:
         Wants=network-online.target
         [Service]
         Type=oneshot
+        Restart=on-failure
+        RemainAfterExit=yes
         Environment=OUTPUT=/run/metadata/coreos
         ExecStart=/usr/bin/mkdir --parent /run/metadata
         ExecStart=/usr/bin/bash -c 'echo "COREOS_CUSTOM_PRIVATE_IPV4=$(ip addr show ens192 | grep "inet 10." | grep -Po "inet \K[\d.]+")\nCOREOS_CUSTOM_PUBLIC_IPV4=$(ip addr show ens192 | grep -v "inet 10." | grep -Po "inet \K[\d.]+")" > ${OUTPUT}'

--- a/docs/provisioning/config-transpiler/dynamic-data.md
+++ b/docs/provisioning/config-transpiler/dynamic-data.md
@@ -10,6 +10,8 @@ aliases:
 
 Sometimes it can be useful to refer to data in a Container Linux Config that isn't known until a machine boots, like its network address. This can be accomplished with [afterburn][afterburn] (previously called `coreos-metadata`). Afterburn is a very basic utility that fetches information about the current machine and makes it available for consumption. By making it a dependency of services which requires this information, systemd will ensure that coreos-metadata has successfully completed before starting these services. These services can then simply source the fetched information and let systemd perform the environment variable expansions.
 
+While the `coreos-metadata.service` runs afterburn, it will not set the hostname. The hostname is set either through an OEM agent or for particular platforms through afterburn in the initramfs. If afterburn supports your platform and is not invoked in the initramfs by default, you can run it later to set the hostname (`--hostname=/etc/hostname`).
+
 As of version 0.2.0, ct has support for making this easy for users. In specific sections of a config, users can enter in dynamic data between `{}`, and ct will handle enabling the coreos-metadata service and using the information it provides.
 
 The available information varies by provider, and is expressed in different variables by coreos-metadata. If this feature is used a `--provider` flag must be passed to ct. Currently, the `etcd` and `flannel` sections are the only ones which support this feature.
@@ -32,7 +34,7 @@ This is the information available in each provider.
 
 ## Custom metadata providers
 
-`ct` also supports custom metadata providers. To use the `custom` platform, modify the coreos-metadata service unit to execute your own custom metadata fetcher. The custom metadata fetcher must write an environment file `/run/metadata/coreos` defining a `COREOS_CUSTOM_*` environment variable for every piece of dynamic data used in the specified Container Linux Config. The environment variables are the same as in the Container Linux Config, but prefixed with `COREOS_CUSTOM_`.
+`ct` also supports custom metadata providers. To use the `custom` platform, create a coreos-metadata service unit to execute your own custom metadata fetcher. The custom metadata fetcher must write an environment file `/run/metadata/coreos` defining a `COREOS_CUSTOM_*` environment variable for every piece of dynamic data used in the specified Container Linux Config. The environment variables are the same as in the Container Linux Config, but prefixed with `COREOS_CUSTOM_`.
 
 ### Example
 
@@ -57,13 +59,17 @@ storage:
 systemd:
   units:
     - name: "coreos-metadata.service"
-      dropins:
-       - name: "use-script.conf"
-         contents: |
-           [Service]
-           # Empty ExecStart= prevents the previously defined ExecStart from running
-           ExecStart=
-           ExecStart=/opt/get-metadata.sh
+      contents: |
+        [Unit]
+        Description=Metadata agent
+        After=nss-lookup.target
+        After=network-online.target
+        Wants=network-online.target
+        [Service]
+        Type=oneshot
+        Restart=on-failure
+        RemainAfterExit=yes
+        ExecStart=/opt/get-metadata.sh
 
 etcd:
   version:                     "3.0.15"
@@ -74,6 +80,8 @@ etcd:
   listen_peer_urls:            "http://{PRIVATE_IPV4}:2380"
   initial_cluster:             "{HOSTNAME}=http://{PRIVATE_IPV4}:2380"
 ```
+
+You can find another example in the [VMware docs](../../installing/cloud/vmware.md).
 
 ## Behind the scenes
 


### PR DESCRIPTION
The custom platform guide talks about using a drop-in unit but when a
non-OEM image is used, it doesn't have the service file at all.
The example used there and in the VMware docs was also lacking some
safety net for temporary malfunctioning metadata servers.

Instruct that the service file should be created instead of using a
drop-in (For existing OEM service files it will work as well to create
the service file under `/etc` which has a higher priority).
Also add some more options to make the oneshot unit more robust.


## How to use

Fixes https://github.com/flatcar-linux/Flatcar/issues/573

## Testing done
