### PR TITLE
reference/SDK: rework SDK docs,cover container SDK

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -139,7 +139,7 @@ some guides to help you choose and make use of the different runtimes.
 ### Developer guides and Reference
 APIs and troubleshooting guides for working with Flatcar Container Linux.
 
-[Developer guides][developer-guides]: Comprehensive guides on developing for Flatcar, working with the SDK, and on building and extening OS images.
+[Developer guides][developer-guides]: Comprehensive guides on developing for Flatcar, working with the SDK, and on building and extending OS images.
 
 [Integrations][integrations]
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -136,10 +136,10 @@ some guides to help you choose and make use of the different runtimes.
  * [Switching from Docker to containerd for Kubernetes][containerd-for-kubernetes]
  * [Authenticating to Container registries][registry-authentication]
 
-### Reference
+### Developer guides and Reference
 APIs and troubleshooting guides for working with Flatcar Container Linux.
 
-[Developer guides][developer-guides]
+[Developer guides][developer-guides]: Comprehensive guides on developing for Flatcar, working with the SDK, and on building and extening OS images.
 
 [Integrations][integrations]
 

--- a/docs/reference/developer-guides/_index.md
+++ b/docs/reference/developer-guides/_index.md
@@ -5,10 +5,12 @@ aliases:
     - ../os/developer-guides
 ---
 
-Most users will never have to build Flatcar Container Linux from source or modify it in any way. If you have a need to modify Flatcar Container Linux, we provide an SDK that allows you to build your own developer images. We also provide OEM functionality for cloud providers and other companies that must customize Flatcar Container Linux to run within their environment.
+This section is aimed at curious developers interested in building Flatcar Container Linux from source and/or in modifying the OS.
+We provide a containerised SDK that allows you to extend Flatcar and to build your own OS images.
+We also provide OEM functionality for cloud providers and similar use cases to customize Flatcar Container Linux to run within their environment.
 
 * [Guide to building custom Flatcar images from source][mod-cl]
-* [Building production images][production-images]
+* [Vending production images / CI integration][production-images]
 * [Building custom kernel modules][kernel-modules]
 * [SDK tips and tricks][sdk-tips]
 * [SDK build process][sdk-bootstrapping]
@@ -21,4 +23,4 @@ Most users will never have to build Flatcar Container Linux from source or modif
 [mod-cl]: sdk-modifying-flatcar
 [kernel-modules]: kernel-modules
 [sdk-bootstrapping]: sdk-bootstrapping
-[mantle-utils]: https://github.com/kinvolk/mantle/blob/flatcar-master/README.md#kola
+[mantle-utils]: https://github.com/flatcar-linux/mantle/blob/flatcar-master/README.md#kola

--- a/docs/reference/developer-guides/sdk-bootstrapping.md
+++ b/docs/reference/developer-guides/sdk-bootstrapping.md
@@ -54,9 +54,9 @@ Using the `--version` command line flag you can continue an SDK build which was
 previously aborted, e.g. after fixing an issue that caused the abort:
 
 ```
-$ sudo ./bootstrap_sdk --version <[release-ID]+[timestamp]>
+~/trunk/src/scripts $ sudo ./bootstrap_sdk --version <[release-ID]+[timestamp]>
 ```
 e.g.
 ```
-$ sudo ./bootstrap_sdk --version 2783.0.0+2021-02-26-1321
+~/trunk/src/scripts $ sudo ./bootstrap_sdk --version 2783.0.0+2021-02-26-1321
 ```

--- a/docs/reference/developer-guides/sdk-building-production-images.md
+++ b/docs/reference/developer-guides/sdk-building-production-images.md
@@ -5,22 +5,18 @@ aliases:
     - ../../os/sdk-building-production-images
 ---
 
-## This document is not maintained
-
-This document still contains useful pointers, but the details are not necessarily up to date.
+FIXME TODO: update to match container builds
 
 ## Introduction
 
-In general the automated process should always be used but in a pinch putting together a release manually may be necessary. All release information is tracked in the [manifest][flatcar-manifest] git repository which is usually organized like so:
+This guide discusses the OS build process and is aimed at audiences comfortable with cutting their very own Flatcar releases. For this purpose we'll have a closer look at the CI automation stubs provided in the [scripts repository][scripts-repo-ci].
 
-* build-109.xml (previous release manifest)
-* build-115.xml (current release manifest)
-* master.xml    (master branch manifest)
-* version.txt   (current version information)
-* default.xml -> master.xml
-* release.xml -> build-115.xml
+It is assumed that readers are familiar with the [SDK][mod-cl] and the general build process outlined in the  [CI automation][scripts-repo-ci].
 
-[flatcar-manifest]: https://github.com/kinvolk/manifest
+
+FIXME TODO: update to match container builds
+
+
 
 ## Tagging releases
 
@@ -70,3 +66,7 @@ The generated production image is bootable as-is by qemu but for a larger ROOT p
 ## Tips and Tricks
 
 We've compiled a [list of tips and tricks](sdk-tips-and-tricks) that can make working with the SDK a bit easier.
+
+
+[scripts-repo-ci]: https://github.com/flatcar-linux/scripts/ci-automation
+[mod-cl]: sdk-modifying-flatcar

--- a/docs/reference/developer-guides/sdk-building-production-images.md
+++ b/docs/reference/developer-guides/sdk-building-production-images.md
@@ -95,8 +95,8 @@ In that case, the above 3 steps are preceded by
 
 1. Compile all core and SDK packages from source to generate a new SDK root FS and build a tarball from that; generate a new SDK release version and set the OS release to the same (SDK) version.
 2. Build a base SDK container image using the tarball from 1.
-   a. build amd64 and arm64 toolchains and related board support
-   b. then, from the image from 2.a, generate from scratch 3 container images - "all", "amd64", and "arm64" with the respective board support included.
+   1. build amd64 and arm64 toolchains and related board support
+   2. then, from the image from 2. i., generate from scratch 3 container images - "all", "amd64", and "arm64" with the respective board support included.
 
 
 Running all 5 steps in one go will produce a new SDK and new OS image based on that new SDK.

--- a/docs/reference/developer-guides/sdk-building-production-images.md
+++ b/docs/reference/developer-guides/sdk-building-production-images.md
@@ -68,5 +68,5 @@ The generated production image is bootable as-is by qemu but for a larger ROOT p
 We've compiled a [list of tips and tricks](sdk-tips-and-tricks) that can make working with the SDK a bit easier.
 
 
-[scripts-repo-ci]: https://github.com/flatcar-linux/scripts/ci-automation
+[scripts-repo-ci]: https://github.com/flatcar-linux/scripts/tree/main/ci-automation
 [mod-cl]: sdk-modifying-flatcar

--- a/docs/reference/developer-guides/sdk-building-production-images.md
+++ b/docs/reference/developer-guides/sdk-building-production-images.md
@@ -141,4 +141,4 @@ Requirements for this server are rather simple - it should have sufficient disk 
 See the `BUILDCACHE_…` settings in the [CI automation settings file](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/ci-config.env) for adapting the build scripts to your environment.
 
 [scripts-repo-ci]: https://github.com/flatcar-linux/scripts/tree/main/ci-automation
-[mod-cl]: sdk-modifying-flatcar.md
+[mod-cl]: sdk-modifying-flatcar

--- a/docs/reference/developer-guides/sdk-building-production-images.md
+++ b/docs/reference/developer-guides/sdk-building-production-images.md
@@ -59,7 +59,7 @@ Versioning is controlled by the [`version.txt` file in the scripts repo](https:/
 Core idea is that a simple
 ```shell
 git checkout 3033.2.0
-git submodules update --init --recursive
+git submodule update --init --recursive
 ```
 will set up the scripts repo for development on top of Flatcar release `3033.2.0`.
 

--- a/docs/reference/developer-guides/sdk-building-production-images.md
+++ b/docs/reference/developer-guides/sdk-building-production-images.md
@@ -23,7 +23,7 @@ Specifically:
 
 Roughly, every second Alpha major release goes Beta, and every second Beta major release goes stable.
 A notable exception is the "3033" major release used in the example below; this release shipped ARM64 support and was moved to Stable faster than usual.
-This allows for swift iterations in the "Alpha" channel while keeping Stable major releases ... well ... stable, and ensuring new major Stable releases introduce meaningful sets of updates and new features.
+This allows for swift iterations in the "Alpha" channel while keeping Stable major releases … well … stable, and ensuring new major Stable releases introduce meaningful sets of updates and new features.
 
 A good way to look at releases and stabilisation through channels is to consider major releases as branches from "main", while Alpha, Beta and Stable releases are distinct points in the lifecycle of a release branch:
 ```
@@ -59,15 +59,15 @@ Versioning is controlled by the [`version.txt` file in the scripts repo](https:/
 Core idea is that a simple
 ```shell
 git checkout 3033.2.0
-git submodules update --init --reqursive
+git submodules update --init --recursive
 ```
 will set up the scripts repo for development on top of Flatcar release `3033.2.0`.
 
-Keeping `version.txt`,and submodules in sync, updating version strings, and generating version tags is one of the main concerns of the build automation scripts.
+Keeping `version.txt` and submodules in sync, updating version strings, and generating version tags is one of the main concerns of the build automation scripts.
 Running a new build via the CI automation will *always* generate a new version.
-This can be non-production version, e.g. nightly build or a PR or branch build - in which case it should be given an appendix following the `MMMM.mm.pp` number.
-The official Flatcar CI uses `-nightly-YYYYMMDD-hhmm` as appendix for nightly builds, e.g. the tag `alpha-3066.0.0-nightly-20221231-0139` would refer to the nightly of the 31st of December, 2021.
-However, custom CI implementations may freely chose to use different appendices.
+This can be non-production version, e.g. nightly build or a PR or branch build - in which case it should be given a suffix following the `MMMM.mm.pp` number.
+The official Flatcar CI uses `-nightly-YYYYMMDD-hhmm` as suffix for nightly builds, e.g. the tag `alpha-3066.0.0-nightly-20221231-0139` would refer to the nightly of the 31st of December, 2021.
+However, custom CI implementations may freely choose to use different suffixes.
 
 
 Version information is a mandatory parameter which the CI implementation must feed into the CI automation scripts. Two of the build steps (detailed on below) take version parameters:
@@ -90,18 +90,18 @@ The Flatcar Container Linux build process consists of
 3. creating one or more vendor-specific image files from the generic OS image.
 
 
-Optionally, the build process may include building the SDK from scratch based on a previous - exisiting - SDK, e.g. to update core build tools and utilities.
-In that case, the above 3 steps are prepended by
+Optionally, the build process may include building the SDK from scratch based on a previous - existing - SDK, e.g. to update core build tools and utilities.
+In that case, the above 3 steps are preceded by
 
 1. Compile all core and SDK packages from source to generate a new SDK root FS and build a tarball from that; generate a new SDK release version and set the OS release to the same (SDK) version.
 2. Build a base SDK container image using the tarball from 1.
-   2.a build amd64 and arm64 toolchains and related board support
-   2.b then, from the image from 2.a, generate from scratch 3 container images - "all", "amd64", and "arm64" with the respective board support included.
+   a. build amd64 and arm64 toolchains and related board support
+   b. then, from the image from 2.a, generate from scratch 3 container images - "all", "amd64", and "arm64" with the respective board support included.
 
 
 Running all 5 steps in one go will produce a new SDK and new OS image based on that new SDK.
 In this pipeline, both a new SDK version as well as a new OS image version are generated.
-This is what we call a "full" (or "full-all") build.
+This is what we call a "full" (or "all-full") build.
 The main use case is for nightly builds of the "main" branches where development of new features happen.
 A new major version release will also use this process (and can be seen as a "special case" of a nightly build of "main").
 New major releases always include a new SDK.
@@ -115,8 +115,8 @@ Only in rare cases it is necessary to update the SDK after a new major version h
 ### Automation scripts
 
 The [build automation scripts][scripts-repo-ci] reflect the 5 steps outlined above; each step is done in a separate script.
-Check out the build automation's README.md to get an overview.
-Each of the scripts contains documentation of the INPUTs and OUTPUTs of the respective build step:
+Check out the build automation's `README.md` to get an overview.
+Each of the scripts contains documentation of the inputs and outputs of the respective build step:
 
 1. [`sdk_bootstrap.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/sdk_bootstrap.sh) builds a new SDK tarball from scratch
 2. [`sdk_container.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/sdk_container.sh) builds an SDK container image from a tarball
@@ -125,7 +125,7 @@ Each of the scripts contains documentation of the INPUTs and OUTPUTs of the resp
 5. [`vms.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/vms.sh) builds vendor-specific images
 
 CI / build automation infrastructure should set up the steps in a build pipeline.
-Artifacts of a preceding build step is fed into the succeeding step.
+Artifacts of a preceding build step are fed into the succeeding step.
 The scripts are meant to implement build logic in a CI agnostic manner; the concrete CI system used (Jenkins, Bamboo, etc.) should require only very minimal glue logic to run builds.
 
 The build scripts should run on most Linux-based nodes out of the box; `git` and `docker` are the only requirements.
@@ -134,11 +134,11 @@ In the Flatcar project, we use Flatcar Container Linux on our CI worker nodes.
 
 ### Auxiliary infrastructure
 
-Apart from infrastructure to run the CI /builds on we also need a server for caching build artifacts.
-Build artifacts are mostly container images - with only few exceptions - and are almost always huge (some gigabites).
+Apart from infrastructure to run the CI / builds on we also need a server for caching build artifacts.
+Build artifacts are mostly container images - with only few exceptions - and are almost always huge (some gigabytes).
 To not overly pollute CI workers' disk space, the build scripts support an "artifact cache" server.
 Requirements for this server are rather simple - it should have sufficient disk space (we use 7TB on Flatcar's CI and can hold ~50 past builds), ssh access (for rsync) and serve artifacts from the (rsync/ssh) path prefix via HTTPS.
-See the `BUILDCACHE_...` settings in the [CI automation settings file](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/ci-config.env) for adapting the build scripts to your environment.
+See the `BUILDCACHE_…` settings in the [CI automation settings file](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/ci-config.env) for adapting the build scripts to your environment.
 
 [scripts-repo-ci]: https://github.com/flatcar-linux/scripts/tree/main/ci-automation
-[mod-cl]: sdk-modifying-flatcar
+[mod-cl]: sdk-modifying-flatcar.md

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -77,7 +77,7 @@ Cloning the repo will have it land on the `main` branch, which can be thought of
 Even though main is smoke-tested in nightly builds, it might occasionally be broken in subtle ways.
 This can make it harder to track down issues introduced by actual changes to Flatcar.
 
-* Release **tags** signify speficic (past) releases, like "stable-2905.2.4" or "beta-3033.1.1". Tags are created in release branches.
+* Release **tags** signify specific (past) releases, like "stable-2905.2.4" or "beta-3033.1.1". Tags are created in release branches.
 * Release **branches** only use major numbers and might contain, on top of the latest release tag, changes for the next upcoming release.
   Branches follow the pattern "flatcar-[MAJOR]".
   Following the tag example above, "flatcar-2905" would contain all changes of major release version 2095 up until stable-2905.2.4, and might contain changes on top of 2905.2.4 slated for a future 2905.2.5 release.
@@ -150,7 +150,7 @@ This leads to `FLATCAR_BUILD_ID` being set (to the output of `git describe --tag
 `run_sdk_container` re-uses containers once started; containers to be re-used are identified by name (see above). 
 Persistence helps with keeping changes in your work environment across container runs.
 **Keep in mind though that a new container will be created if the working commit in the scripts repository changes**.
-This is usually derired to prevent version muddling.
+This is usually desired to prevent version muddling.
 It can be explicitly overridden by using the `-n <name>` argument to `run_sdk_container`.
 
 
@@ -389,7 +389,7 @@ Lastly, the SDK might lack unmasks if the respective architecture is masked in t
 ```
 
 To proceed, remove the architecture mask in the ebuild file (remove the `~` - for example, change `~arm64` to `arm64`) and re-run emerge.
-FLatcar follows its own stabilisation process (through the Alpha - Beta - Stable channels); it's perfectly fine to unmask a package upstream considers unstable.
+Flatcar follows its own stabilisation process (through the Alpha - Beta - Stable channels); it's perfectly fine to unmask a package upstream considers unstable.
 
 If you want to use optional build flags (USE flags in Gentoo lingo) e.g. for compiling optional library support into the application, add the new package and the respective USE flag(s) to `src/third_party/portage-stable/profiles/base/package.use`.
 

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -128,13 +128,13 @@ This file is updated on each release and reflects the SDK and OS versions corres
 
 ```shell
 $ cat sdk_container/.repo/manifests/version.txt
-FLATCAR_VERSION=3066.0.0
-FLATCAR_VERSION_ID=3066.0.0
+FLATCAR_VERSION=3066.1.0
+FLATCAR_VERSION_ID=3066.1.0
 FLATCAR_BUILD_ID=""
-FLATCAR_SDK_VERSION=3066.0.0
+FLATCAR_SDK_VERSION=3066.1.0
 ```
 
-The example above is from the Alpha branch of the 3066 major release at the time of writing.
+The example above is from the release / maintenance branch of the 3066 major release at the time of writing (3066 was in the Beta channel at that time).
 
 
 ### Start the SDK
@@ -144,7 +144,7 @@ This will download the container image of the respective version if not present 
 
 ```shell
 $ ./run_sdk_container -t
-sdk@flatcar-sdk-all-3066_0_0_os-alpha-3066_0_0-5-gcf4ff44a ~/trunk/src/scripts $ cat sdk_container/.repo/manifests/version.txt
+sdk@flatcar-sdk-all-3066_0_0_os-beta-3066_1_0-gcf4ff44a  ~/trunk/src/scripts $ cat sdk_container/.repo/manifests/version.txt
 ```
 
 The `-t` flag is used to tell docker to allocate a TTY. It should be omitted when calling `run_sdk_container` from a script.
@@ -155,15 +155,15 @@ By default, the name of the container contains SDK and OS image version.
 After starting, the version file will have been updated:
 
 ```shell
-sdk@flatcar-sdk-all-3066_0_0_os-alpha-3066_0_0-5-gcf4ff44a ~/trunk/src/scripts $ cat sdk_container/.repo/manifests/version.txt
-FLATCAR_VERSION=3066.0.0+5-gcf4ff44a
-FLATCAR_VERSION_ID=3066.0.0
+sdk@flatcar-sdk-all-3066_0_0_os-beta-3066_1_0-gcf4ff44a ~/trunk/src/scripts $ cat sdk_container/.repo/manifests/version.txt
+FLATCAR_VERSION=3066.1.0+5-gcf4ff44a
+FLATCAR_VERSION_ID=3066.0.1
 FLATCAR_BUILD_ID="5-gcf4ff44a"
 FLATCAR_SDK_VERSION=3066.0.0
 ```
 
-We're basing our work on release 3066.0.0 in this example, the current branch has 5 patches on top of that release, and the latest patch has the shortlog hash `cf4ff44a`.
-This leads to `FLATCAR_BUILD_ID` being set (to the output of `git describe --tags`) and is reflected in the container name `...os-alpha-3066_0_0-5-gcf4ff44a`.
+We're basing our work on release 3066.1.0 in this example, the current branch has 5 patches on top of that release, and the latest patch has the shortlog hash `cf4ff44a`.
+This leads to `FLATCAR_BUILD_ID` being set (to the output of `git describe --tags`) and is reflected in the container name `...os-beta-3066_1_0-5-gcf4ff44a`.
 
 
 #### A note on persistence

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -24,7 +24,7 @@ Please direct questions and suggestions to the [#flatcar:matrix.org Matrix chann
 
 **tl;dr** Check out a release branch and start the SDK (this uses the current Alpha release branch).
 ```shell
-$ git clone https://github.com/flatcar-linux/scripts.git
+$ git clone --recurse-submodules https://github.com/flatcar-linux/scripts.git
 $ cd scripts
 $ branch="$(git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1)"
 $ ./checkout "$branch"
@@ -64,7 +64,7 @@ The [scripts repository][scripts] - among other things - contains SDK wrapper sc
 A good way to think of the scripts repo is this being Flatcar's "SDK repo".
 
 ```shell
-$ git clone https://github.com/flatcar-linux/scripts.git
+$ git clone --recurse-submodules https://github.com/flatcar-linux/scripts.git
 $ cd scripts
 ```
 
@@ -104,7 +104,7 @@ We provide a helper script to check out tags or branches and keeping submodules 
 $ ./checkout [branch-or-tag-from-above]
 ```
 
-This wikk check out the branch or tag in the top-level `scripts` directory and update the submodules, depending on wheter a branch or tag was specified:
+This will check out the branch or tag in the top-level `scripts` directory and update the submodules, depending on wheter a branch or tag was specified:
 - a TAG already includes the correct submodule pinnings, so submodules are simply updated to point to the correct pinned commit.
 - a BRANCH will cause the helper script to check out a branch of the same name in both submodules, and fast-forward to the latest upstream branch tip.
 
@@ -212,7 +212,7 @@ If no architecture is specified then AMD64 will be used by default.
 
 ### Build the OS image packages
 
-It's likely this won't *actually* build the packages but rather download pre-built packages from the Flatcar binary package cache.
+Beware, it's likely this won't *actually* build the packages but rather download pre-built packages from the Flatcar binary package cache (see below on how to force-rebuild a package that you modified).
 The package cache is updated on every release.
 
 ```shell
@@ -310,7 +310,7 @@ For more information on Gentoo in general please refer to the [Gentoo devmanual]
 
 When entering the SDK you are in the `~/trunk/src/scripts` repository which can be seen as the build system.
 It is one of the three repositories that define a Flatcar build:
-1. flatcar-scripts (the directory you're in) contains high-level build scripts to build all packages for an image, to build an image, and to bootstrap an SDK.
+1. `scripts` (the directory you're in) contains high-level build scripts to build all packages for an image, to build an image, and to bootstrap an SDK.
 2. `~/trunk/src/third_party/portage-stable` contains ebuild files of all packages close to (or identical to) Gentoo upstream.
 3. `~/trunk/src/third_party/coreos-overlay` contains Flatcar specific packages like ignition and mayday, as well as Gentoo packages which were significantly modified for Flatcar, like the Linux kernel, or systemd.
 

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -253,7 +253,7 @@ You can log in via SSH keys or with a different ssh port by running this example
 
 Now for the interesting part! We are going to discuss 2 ways of making changes: adding or upgrading a package, and modifying the kernel configuration.
 
-### A brief introduction to Gentoo how it relates to the SDK
+### A brief introduction to Gentoo and how it relates to the SDK
 
 Flatcar Container Linux is based on ChromiumOS, which is based on Gentoo.
 While the ChromiumOS heritage has faded and is barely visible nowadays, we heavily leverage Gentoo processes and tools.

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -122,6 +122,10 @@ FLATCAR_SDK_VERSION=3066.1.0
 The example above is from the release / maintenance branch of the 3066 major release at the time of writing (3066 was in the Beta channel at that time).
 
 
+**NOTE** that the version file at `sdk_container/.repo/manifests/version.txt` will be updated by `run_sdk_container` to include the git shortlog hash.
+This file is under revision control because it pins the latest official OS release and SDK version of the branch you're working on.
+**If you like to switch branches later, make sure to run `git checkout sdk_container/.repo/manifests/version.txt` to revert the change made by `run_sdk_container`.**
+
 ### Start the SDK
 
 We are now set to run the SDK container.
@@ -347,9 +351,11 @@ $ ./run_sdk_container.sh -t
 # optional - add missing dependencies, see line 2 ff. above
 ~/trunk/src/scripts $ ./build_image
 ~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --format qemu
-~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
-~/trunk/src/scripts $ ssh core@localhost -p 2222
-# run new software to verify it works
+# from outside the container, i.e. on the host:
+scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+# in a different terminal on the host:
+scripts $ ssh core@localhost -p 2222
+# now run new software to verify it works
 core@localhost ~ $ ...
 ```
 
@@ -445,8 +451,16 @@ This will allow us to validate whether the software added works to our expectati
 ```shell
 ~/trunk/src/scripts $ ./build_image
 ~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --format qemu
-~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
-~/trunk/src/scripts $ ssh core@localhost -p 2222
+```
+
+After building the qemu image, we can now start it and SSH into the new OS image's instance.
+Here, we can validate whether our updated / added application works as expected.
+We start the qemu instance *on the host*, i.e. outside the container, so we can better interact with it from the host.
+Then, in a *different terminal*, we ssh into the host:
+```shell
+scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+# switch terminals
+scripts $ ssh core@localhost -p 2222
 core@localhost ~ $ ...
 ```
 
@@ -483,8 +497,11 @@ $ ./run_sdk_container.sh -t
 ~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild package
 ~/trunk/src/scripts $ ./build_image --board=amd64-usr
 ~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
-~/trunk/src/scripts $ ssh core@localhost -p 2222
+
+# on the host
+scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+# in a different terminal on the host:
+scripts $ ssh core@localhost -p 2222
 core@localhost ~ $ ...
 
 ~/trunk/src/scripts $ diff kernel-config.orig kernel-config.mine > ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/my.diff
@@ -495,21 +512,12 @@ core@localhost ~ $ ...
 ~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-modules
 ~/trunk/src/scripts $ ./build_image --board=amd64-usr
 ~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
-~/trunk/src/scripts $ ssh core@localhost -p 2222
 
-~/trunk/src/scripts $ diff kernel-config.orig kernel-config.mine > ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/my.diff
-~/trunk/src/scripts $ cd ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/
-~/trunk/src/third_party/coreos-overlay/sys-kernel/coreos-modules/files/ $ vim -O commonconfig* amd64_defconfig* my.diff
-~/trunk/src/third_party/coreos-overlay/sys-kernel/coreos-modules/files/ $ rm my.diff
-
-~/trunk/src/scripts $ cd ~/trunk/src/scripts 
-~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-kernel
-~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-modules
-~/trunk/src/scripts $ ./build_image --board=amd64-usr
-~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
-~/trunk/src/scripts $ ssh core@localhost -p 2222
+# on the host
+scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+# in a different terminal on the host:
+scripts $ ssh core@localhost -p 2222
+core@localhost ~ $ ...
 ```
 
 </td></tr></table>
@@ -603,8 +611,14 @@ These packages can now be picked up by the image builder script. Let’s build a
 ```shell
 ~/trunk/src/scripts $ ./build_image --board=amd64-usr
 ~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
-~/trunk/src/scripts $ ssh core@localhost -p 2222
+```
+
+*On the host*, start the qemu VM.
+Then, *in a different terminal*, ssh into the VM and validate your modifications.
+```shell
+scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+scripts $ ssh core@localhost -p 2222
+core@localhost ~ $ ...
 ```
 
 After we’ve verified that our modifications work as expected, let’s persist the changes into the ebuild file - in `sys-kernel/coreos-modules` (as previously mentioned).
@@ -623,8 +637,14 @@ Finally, we’ll rebuild kernel and modules using the updated ebuild, to make su
 ~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-modules
 ~/trunk/src/scripts $ ./build_image --board=amd64-usr
 ~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
-~/trunk/src/scripts $ ssh core@localhost -p 2222
+```
+
+*On the host*, start the qemu VM.
+Then, *in a different terminal*, ssh into the VM and validate your modifications.
+```shell
+scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+scripts $ ssh core@localhost -p 2222
+core@localhost ~ $ ...
 ```
 
 

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -276,7 +276,7 @@ In these stacks, “upper” level packages override “lower” level ones.
 The Flatcar build system uses a fork of Gentoo upstream’s [portage-stable](https://github.com/flatcar-linux/portage-stable) as its base, and the overlay repository [coreos-overlay](https://github.com/flatcar-linux/coreos-overlay) for Flatcar specific modifications and packages on top.
 
 Packages are built using "ebuild" files.
-These files contain a package’s dependencies - both build and runtime - as well as implement callbacks for downloading, patching, building, and installing a package.
+These files contain dependencies of a package - both build and runtime - as well as implement callbacks for downloading, patching, building, and installing the package.
 The callbacks in these ebuild files are written in shell.
 The Gentoo package system - portage - will, when building / installing a package, run the respective callbacks in order (e.g. `src_fetch()` for downloading package sources, and `src_compile()` for building).
 Common ebuild functions shared across many packages are implemented via classes (in `eclass/`) which can be inherited by package ebuilds.

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -102,7 +102,7 @@ $ git checkout [branch-from-above]
 $ git submodule update
 ```
 
-To verify the version in use, consult the versionfile.
+To verify the version in use, consult the version file.
 This file is updated on each release and reflects the SDK and OS versions corresponding to the the current commit.
 
 ```shell
@@ -222,7 +222,7 @@ $ ./image_to_vm.sh --from=../build/images/arm64-usr/developer-latest [--board=..
 For other vendor images, pass the `--format=` parameter (see `./image_to_vm.sh --help`).
 In general, `image_to_vm.sh` will read the generic disk image, install any vendor specific tools to the OEM partition where applicable (e.g. Azure VM tools for the Azure VM), and produce a vendor specific image. In the case of QEMU, a qcow2 image is produced. QEMU does not require vendor specific tooling in the OEM partition.
 
-On the host outside the container, the image(s) built are located in `__build__/images/...`.
+On the host outside the container, the image(s) built are located in `__build__/images/…`.
 This directory is also bind-mounted into the container by `run_sdk_container`.
 
 ### Booting
@@ -260,7 +260,7 @@ While the ChromiumOS heritage has faded and is barely visible nowadays, we heavi
 
 Contrary to traditional Linux distributions, Gentoo applications and “packages” are compiled at installation time.
 Gentoo itself does not ship packages - instead, it consists of a massive number of ebuild files to build applications at installation time (that’s an oversimplification as there are binary package caches, but that’s beyond the scope of this document).
-While the Flatcar SDK can be understood as a Gentoo derivate, the OS image is special.
+While the Flatcar SDK can be understood as a Gentoo derivative, the OS image is special.
 The OS image is not self-contained, i.e. it cannot install / update packages - it lacks both a compiler to build packages as well as tools to orchestrate builds and install the resulting binaries.
 Instead, OS images are built via the SDK, by building packages in the SDK, then installing the binaries into a chroot environment.
 From the chroot environment, the resulting OS image is generated.
@@ -320,7 +320,7 @@ $ ./run_sdk_container.sh -t
 ~/trunk/src/scripts $ cp gentoo/eclass/<eclass-name>.eclass ../third_party/portage-stable/eclass/
 ~/trunk/src/scripts $ emerge-amd64-usr --newuse <group>/<package>
 # optional - unmask package
-~/trunk/src/scripts $ vim ../third_party/portage-stable/<group>/<package>/<package-version>.ebuild
+~/trunk/src/scripts $ vim ../third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
 # remove '~' from arm64 and amd64
 ~/trunk/src/scripts $ emerge-amd64-usr --newuse <group>/<package>
 # optional - add missing dependencies, see line 2 ff. above
@@ -388,7 +388,7 @@ Lastly, the SDK might lack unmasks if the respective architecture is masked in t
   =<other-group>/<other-package> **
 ```
 
-To proceed, remove the architecture mask in the ebuild file (remove the `~` - for example, change `~arm64` to `arm64`) and re-run emerge.
+To proceed, add the package name and version, and its masked architectures to the `package.accept_keywords` file inside the `coreos` profile. Which `package.accept_keywords` file should be updated depends on couple factors - whether it is needed for both SDK and OS image or only for SDK or only for OS image, whether it is needed for both AMD64 and ARM64 images, or only for AMD64 or only for ARM64. Please refer to `README.md` in coreos-overlay for a summary about profiles
 Flatcar follows its own stabilisation process (through the Alpha - Beta - Stable channels); it's perfectly fine to unmask a package upstream considers unstable.
 
 If you want to use optional build flags (USE flags in Gentoo lingo) e.g. for compiling optional library support into the application, add the new package and the respective USE flag(s) to `src/third_party/portage-stable/profiles/base/package.use`.
@@ -499,7 +499,7 @@ To modify the configuration of a package we will run its individual build steps 
 This will allow for pausing after downloading the sources, to change the source tree configuration before building and installing.
 
 Our first step is to set you all up with a pre-configured stock Flatcar Linux kernel to base your modifications on.
-The Flatcar Linux kernel build is split over multiple gentoo ebuild files which all reside in <code>[coreos-overlay/sys-kernel/](https://github.com/kinvolk/coreos-overlay/tree/main/sys-kernel)</code>:
+The Flatcar Linux kernel build is split over multiple gentoo ebuild files which all reside in [`coreos-overlay/sys-kernel/`](https://github.com/kinvolk/coreos-overlay/tree/main/sys-kernel):
 
 *   `coreos-sources/` for pulling the kernel sources from git.kernel.org
 *   `coreos-kernel/` for building the main kernel (vmlinuz)

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -27,13 +27,7 @@ Please direct questions and suggestions to the [#flatcar:matrix.org Matrix chann
 $ git clone https://github.com/flatcar-linux/scripts.git
 $ cd scripts
 $ branch="$(git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1)"
-$ git checkout "$branch"
-$ git submodule init
-$ git submodule update
-$ for s in sdk_container/src/third_party/coreos-overlay/ sdk_container/src/third_party/portage-stable; do
-$   git -C "$s" checkout "$branch"
-$   git -C "$s" pull --rebase
-$ done
+$ ./checkout "$branch"
 $ ./run_sdk_container -t
 ```
 
@@ -61,8 +55,8 @@ There are 2 ways to use the SDK container:
 2. Wrapped: Uses a wrapper script to run the container and to bind-mount the local scripts directory into the container.
    **This is the recommended way of using the SDK.**
 
-**NOTE** that currently, Docker is required to run the SDK.
-While work on supporting other runtimes (e.g. Podman) is ongoing, the wrapper scripts currently only support Docker.
+**NOTE** The SDK container supports being run on docker or podman, with docker taking preference when both are available.
+The wrapper scripts will auto-detect which one is available, and use it.
 
 ### Clone the scripts repo
 
@@ -72,8 +66,6 @@ A good way to think of the scripts repo is this being Flatcar's "SDK repo".
 ```shell
 $ git clone https://github.com/flatcar-linux/scripts.git
 $ cd scripts
-$ git submodule init
-$ git submodule update
 ```
 
 #### Optionally, pick a release tag or branch
@@ -106,22 +98,15 @@ $ git tag -l | grep -E 'stable-[0-9.]+$' | sort | tail -n 1
 ```
 (replace `stable` with `beta` or `alpha` in accordance with your needs).
 
-Now check out the tag or branch and update the submodules:
+We provide a helper script to check out tags or branches and keeping submodules aligned. Just run:
 
 ```shell
-$ git checkout [branch-or-tag-from-above]
-$ git submodule update
+$ ./checkout [branch-or-tag-from-above]
 ```
 
-**Note**: When using a branch, the submodule pinnings might be outdated, so it's always a good idea to pull the latest branch tips for the submodules, too.
-This is not an issue with release tags; a release tag always pins the submodule state at the point of release.
-
-```shell
-$ for s in sdk_container/src/third_party/coreos-overlay/ sdk_container/src/third_party/portage-stable; do
-$   git -C "$s" checkout [branch]
-$   git -C "$s" pull --rebase
-$ done
-```
+This wikk check out the branch or tag in the top-level `scripts` directory and update the submodules, depending on wheter a branch or tag was specified:
+- a TAG already includes the correct submodule pinnings, so submodules are simply updated to point to the correct pinned commit.
+- a BRANCH will cause the helper script to check out a branch of the same name in both submodules, and fast-forward to the latest upstream branch tip.
 
 Lastly, to verify the version in use, consult the version file.
 This file is updated on each release and reflects the SDK and OS versions corresponding to the the current commit.

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -304,7 +304,7 @@ Packages are built using "ebuild" files.
 These files contain dependencies of a package - both build and runtime - as well as implement callbacks for downloading, patching, building, and installing the package.
 The callbacks in these ebuild files are written in shell.
 The Gentoo package system - portage - will, when building / installing a package, run the respective callbacks in order (e.g. `src_fetch()` for downloading package sources, and `src_compile()` for building).
-Common ebuild functions shared across many packages are implemented via classes (in `eclass/`) which can be inherited by package ebuilds.
+Common ebuild functions shared across many packages are implemented via eclasses (in `eclass/`) which can be inherited by package ebuilds.
 
 
 For more information on Gentoo in general please refer to the [Gentoo devmanual](https://devmanual.gentoo.org/).
@@ -415,7 +415,7 @@ Lastly, the SDK might lack unmasks if the respective architecture is masked in t
   =<other-group>/<other-package> **
 ```
 
-To proceed, add the package name and version, and its masked architectures to the `package.accept_keywords` file inside the `coreos` profile. Which `package.accept_keywords` file should be updated depends on couple factors - whether it is needed for both SDK and OS image or only for SDK or only for OS image, whether it is needed for both AMD64 and ARM64 images, or only for AMD64 or only for ARM64. Please refer to `README.md` in coreos-overlay for a summary about profiles
+To proceed, add the package name and version, and its masked architectures to the `package.accept_keywords` file inside the `coreos` profile. Which `package.accept_keywords` file should be updated depends on couple factors - whether it is needed for both SDK and OS image or only for SDK or only for OS image, whether it is needed for both AMD64 and ARM64 images, or only for AMD64 or only for ARM64. Please refer to `README.md` in coreos-overlay for a summary about profiles.
 Flatcar follows its own stabilisation process (through the Alpha - Beta - Stable channels); it's perfectly fine to unmask a package upstream considers unstable.
 
 If you want to use optional build flags (USE flags in Gentoo lingo) e.g. for compiling optional library support into the application, add the new package and the respective USE flag(s) to `src/third_party/portage-stable/profiles/base/package.use`.

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -6,220 +6,181 @@ aliases:
     - ../../os/sdk-modifying-coreos
 ---
 
-The guides in this document aim to enable engineers to update, and to extend, packages in both the Flatcar OS image as well as the SDK, to suit their own needs. Overarching goal of this collection of how-tos is to help you to scratch your own itch, to set you up to play with Flatcar. We’ll cover everything you need to make the changes you want, and to produce an image for the runtime environment(s) you want to use Flatcar in (e.g. AWS, qemu, Packet, etc). By the end of the guide you will build a developer image that you can run under qemu and have tools for making changes to the OS image like adding or removing packages, or shipping custom kernels. Note that we chose this guide's "qemu" image target solely to enable local testing; the same process can be used to produce images for any and all targets (cloud providers etc.) supported by Flatcar.
+The guides in this document aim to enable engineers to update, and to extend, packages in both the Flatcar OS image as well as the SDK, to suit their own needs.
+Overarching goal of this collection of how-tos is to help you to scratch your own itch, to set you up to play with Flatcar.
+We’ll cover everything you need to make the changes you want, and to produce an image for the runtime environment(s) you want to use Flatcar in (e.g. AWS, qemu, Packet, etc).
+By the end of the guide you will build a developer image that you can run under qemu and have tools for making changes to the OS image like adding or removing packages, or shipping custom kernels.
+Note that we chose this guide's "qemu" image target solely to enable local testing; the same process can be used to produce images for any and all targets (cloud providers etc.) supported by Flatcar.
+
+**Note** there is a "tl;dr" paragraph at the start of each section which summarises the commands discussed in the section.
 
 Flatcar Container Linux is an open source project. All of the source for Flatcar Container Linux is available on [github][github-flatcar]. If you find issues with these docs or the code please send a pull request.
 
-Direct questions and suggestions to the [IRC channel][irc] or [mailing list][flatcar-dev].
+Please direct questions and suggestions to the [#flatcar:matrix.org Matrix channel][matrix] or [mailing list][flatcar-dev].
 
 ## Getting started
 
-You’ll need the latest Flatcar SDK installed before we get to the fun part. This is discussed below. After you're set up with an SDK we’ll also do a full image build so you start from a known-good, working Flatcar image. So let's get set up with an SDK chroot and build a bootable image of Flatcar Container Linux. The SDK chroot has a full toolchain and isolates the build process from quirks and differences between host OSes. The SDK must be run on an x86-64 Linux machine, the distro should not matter (Ubuntu, Fedora, etc).
+<table><tr><td>
 
-### Prerequisites
-
-**System requirements to get started**
-
-* curl
-* git
-* bzip2
-* gpg
-* sudo
-
-Optionally:
-* golang if you want to compile cork yourself (see below)
-
-
-**You also need a proper git setup**
-
+**tl;dr** Check out a release branch and start the SDK (this uses the current Alpha release branch).
 ```shell
-$ git config --global user.email "you@example.com"
-$ git config --global user.name "Your Name"
+$ git clone https://github.com/flatcar-linux/scripts.git
+$ cd scripts
+$ git checkout $(git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1) 
+$ git submodule init
+$ git submodule update
+$ ./run_sdk_container -t
 ```
 
-**NOTE**: Do the git configuration as a normal user and not with sudo.
+</td></tr></table>
 
+Flatcar Container Linux uses a containerised SDK; pre-built container images are available via [ghcr.io][ghcr-sdk].
+The SDK itself is containerised, but it requires version information and package build instructions to build an OS image. 
+This information is contained in the scripts repository:
 
-**Finally, you'll need an ssh-agent set up**
-
-Make sure to set up ssh-agent, otherwise github will return access denied even for our public repos. In most cases this is not an issue as an ssh-agent is enabled by default in most distros. The ssh-agent is required as the chroot will access your SSH keys through the agent’s socket to authenticate github access.
-
-### Using Cork
-
-The `cork` utility, included in the Flatcar Container Linux [mantle](https://github.com/kinvolk/mantle) project, is used to create and work with an SDK chroot.
-
-When installing an SDK, cork will
-* download an SDK chroot tarball
-* unpack the tarball in a local directory
-* clone Flatcar Container Linux repositories into the local SDK directory
-
-After the installation finished, `cork enter` may be used to enter the SDK chroot environment.
-
-
-First, download the cork utility and verify it with the signature:
-
-```shell
-$ curl -L -o cork https://github.com/kinvolk/mantle/releases/download/v0.17.0/cork-0.17.0-amd64
-$ curl -L -o cork.sig https://github.com/kinvolk/mantle/releases/download/v0.17.0/cork-0.17.0-amd64.sig
-$ curl -LO https://flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
-$ gpg --import Flatcar_Image_Signing_Key.asc
-$ rm Flatcar_Image_Signing_Key.asc
-$ gpg --verify cork.sig cork
+```
+scripts
+   +--sdk_container
+          +---------src
+          |          +--third_party
+          |                  +------coreos-overlay
+          |                  +------portage-stable
+          `---------.repo
+                     +----manifests
+                           +-------- version.txt
 ```
 
-The `gpg --verify` command should output something like this:
+There are 2 ways to use the SDK container:
+1. Standalone: Run the container and clone the scripts repo inside the container.
+   This is great for one-shot SDK usage; it's not optimal for sustained OS development since versioning is unclear and changes might get lost.
+2. Wrapped: Uses a wrapper script to run the container and to bind-mount the local scripts directory into the container.
+   **This is the recommended way of using the SDK.**
+
+**NOTE** that currently, Docker is required to run the SDK.
+While work on supporting other runtimes (e.g. Podman) is ongoing, the wrapper scripts currently only support Docker.
+
+### Clone the scripts repo
+
+The [scripts repository][scripts] - among other things - contains SDK wrapper scripts, a `version.txt` with release version information, and both the [coreos-overlay][coreos] and [portage-stable][portage] ebuild repositories as git submodules (more on ebuilds later).
+A good way to think of the scripts repo is this being Flatcar's "SDK repo".
 
 ```shell
-gpg: Signature made Tue Oct  5 12:57:37 2021 -00
-gpg:                using RSA key 858A560F97C9AEB22EC1C732961DDDD5250D4A42
-gpg: Good signature from "Flatcar Buildbot (Official Builds) <buildbot@flatcar-linux.org>" [unknown]
-Primary key fingerprint: F88C FEDE FF29 A5B4 D952  3864 E25D 9AED 0593 B34A
-     Subkey fingerprint: 858A 560F 97C9 AEB2 2EC1  C732 961D DDD5 250D 4A42
+$ git clone https://github.com/flatcar-linux/scripts.git
+$ cd scripts
+$ git submodule init
+$ git submodule update
 ```
 
-Then proceed with the installation of the cork binary to a location on your path:
+#### Optionally, pick a release tag or branch
+
+Cloning the repo will have it land on the `main` branch, which can be thought of as "alpha-next" - i.e. the next major Alpha release.
+Even though main is smoke-tested in nightly builds, it might occasionally be broken in subtle ways.
+This can make it harder to track down issues introduced by actual changes to Flatcar.
+
+* Release **tags** signify speficic (past) releases, like "stable-2905.2.4" or "beta-3033.1.1". Tags are created in release branches.
+* Release **branches** only use major numbers and might contain, on top of the latest release tag, changes for the next upcoming release.
+  Branches follow the pattern "flatcar-[MAJOR]".
+  Following the tag example above, "flatcar-2905" would contain all changes of major release version 2095 up until stable-2905.2.4, and might contain changes on top of 2905.2.4 slated for a future 2905.2.5 release.
+
+
+It is generally recommended to base work on the latest Alpha release.
+While new features should target `main` at merge time, Alpha is a tested release and therefore offers a more stable foundation to base work on.
+At the same time, Alpha is not too far away from `main` so the risk of merge-time conflicts should be low.
+
+Get the latest Alpha release branch:
 
 ```shell
-$ chmod +x cork
-$ mkdir -p ~/.local/bin
-$ mv cork ~/.local/bin
-$ export PATH=$PATH:$HOME/.local/bin
+$ git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1
 ```
 
-You may want to add the `PATH` export to your shell profile (e.g. `.bashrc`).
+If the goal is to reproduce and to fix a bug of a release other than Alpha, it is recommended to base the work on the latest point release of the respective major version instead of Alpha. All currrently "active" major versions can be found at the top of the [releases][flatcar-releases] web page.
 
-**Alternatively, clone the mantle repo and build cork from sources**
-
-If you want to build cork from sources instead of using an official release, you'll need golang installed as mantle is written in go.
+Check out the branch and update the submodules:
 
 ```shell
-$ git clone git@github.com:kinvolk/mantle.git
-$ cd mantle
-$ ./build cork
+$ git checkout [branch-from-above]
+$ git submodule update
 ```
 
-Now you want to make the resulting `bin/cork` binary part of your `$PATH`. Some prefer a symlink `~/.local/bin/cork -> ~/code/mantle/bin/cork ` ( `~/.local/bin/` often is in `$PATH` already as per `.bashrc`) - but you’re free to make your own arrangements as you see fit. Simply running `export PATH="$PATH:$(pwd/bin)"` in the mantle repo directory works (for the current shell), too.
-
-Next, use the cork utility to download and install the SDK and related repositories. This will hold all of Flatcar's git repos as well as the SDK chroot. For building all binaries and images, about 20 gigabytes of free disk space are recommended.
-
-**NOTE** that you can use multiple SDKs in separate directories (and separate shells, of course) at the same time.
-
-First, we'll create a directory cork will install the SDK to.
-```shell
-$ mkdir flatcar-sdk
-$ cd flatcar-sdk
-```
-
-**NOTE** if you are considering installing the SDK to `/tmp` or any directory mounted with `nodev`, then the SDK will not be properly installed. You must remount the directory without `nodev` specified. Errors such as `permission denied` upon `cork install` otherwise will be seen and it will prevent you from getting the SDK up and running.
-
-Before we download and install the SDK, we need to pick a release. Generally it is recommended that people base their work on the latest Alpha release (both SDK and OS image). This guarantees a sane, known-good base to get started with - as Alpha releases are required to pass the full range of release tests - while at the same time staying reasonably current for, e.g., filing a PR later.
-
-Get a list of all Alpha releases:
-```shell
-$ curl -s https://www.flatcar-linux.org/releases-json/releases.json \
-         | jq -r 'to_entries[] | "\(.value | .channel) tag: v\(.key) - kernel \(.value | .major_software.kernel[0]), released \(.value | .release_date)"' \
-         | grep 'alpha tag'
-```
-
-Then you can use the "alpha tag" value (without leading 'v') with cork's `--manifest-branch flatcar-alpha-[VERSION]` option to install that SDK version. E.g. to install Alpha release 3033.0.0, run
+To verify the version in use, consult the versionfile.
+This file is updated on each release and reflects the SDK and OS versions corresponding to the the current commit.
 
 ```shell
-$ cork create --verbose --manifest-branch flatcar-alpha-3033.0.0    # Be prepared: This will request root permisions via sudo after downoad!
-$ cork enter   # This will also request root permisions via sudo
+$ cat sdk_container/.repo/manifests/version.txt
+FLATCAR_VERSION=3066.0.0
+FLATCAR_VERSION_ID=3066.0.0
+FLATCAR_BUILD_ID=""
+FLATCAR_SDK_VERSION=3066.0.0
 ```
 
-Note that we're using the `--verbose` flag with `cork create` so you get a progress bar for downloading the SDK chroot tarball. The tarball is ~1.4GB in size, so the download can take some time. After the download finished, cork will install the SDK chroot - at that point it will require `sudo` and might prompt for your user password. Note that this prompt can time out if you weren't looking (since the download can take time). Should that happen, run
-```shell
-$ rm -rf chroot
-$ cork create ...   # same options as above, but it will use the cached SDK (i.e. not download again)
-```
+The example above is from the Alpha branch of the 3066 major release at the time of writing.
 
-As discussed above you most probably want to base your work on the latest Alpha release. Technically, you could use any release - for instance, if you want to fix a bug in Beta or Stable - by using the appropriate `--manifest-branch` option. Basing your work on the development branches for filing PRs to `main` or the `flatcar-MAJOR` maintenance branches is not covered here but under [the section for using nightly packages][sdktips]. For the given release manifest the SDK checks out the right git branches with matching ebuild files and you should not change them unless you follow the instructions on setting up the nightly binary package URLs.
-```shell
-$ cork create --verbose --manifest-branch flatcar-stable-2905.2.6
-```
-to base your work on the Stable 2905.2.6 release published on October 25th, 2021.
 
-### Enter the SDK
+### Start the SDK
 
-Run
-```shell
-$ cork enter
-```
-
-Verify you are in the SDK chroot:
+We are now set to run the SDK container.
+This will download the container image of the respective version if not present locally, and then start the container with the local directory bind-mounted.
 
 ```shell
-$ grep NAME /etc/os-release
-NAME="Flatcar Container Linux by Kinvolk"
+$ ./run_sdk_container -t
+sdk@flatcar-sdk-all-3066_0_0_os-alpha-3066_0_0-5-gcf4ff44a ~/trunk/src/scripts $ cat sdk_container/.repo/manifests/version.txt
 ```
 
-To leave the SDK chroot, simply run `exit`.
+The `-t` flag is used to tell docker to allocate a TTY. It should be omitted when calling `run_sdk_container` from a script.
 
-To use the SDK chroot in the future, run `cork enter` from the directory you installed the SDK to (i.e. where you ran `cork create`).
-
-## Building an image
-
-### A brief introduction to Gentoo
-
-Flatcar Container Linux is based on ChromiumOS, which is based on Gentoo. While the ChromiumOS heritage has faded and is barely visible nowadays, we heavily leverage Gentoo processes and tools.
-
-Contrary to traditional Linux distributions, Gentoo applications and “packages” are compiled at installation time. Gentoo itself does not ship packages - instead, it consists of a massive number of ebuild files to build applications at installation time (that’s an oversimplification as there are binary package caches, but that’s beyond the scope of this document).
-
-Packages are organised in a flat hierarchy of `<group>/<package>`. For instance, Linux kernel related ebuilds are in the group `sys-kernel` (kernel sources, headers, off-tree modules, etc.), while mail clients like thunderbird or mutt are in group `mail-client`. Each package may contain ebuild files for multiple versions, e.g. `sys-kernel/gentoo-kernel/` contains ebuilds for building 5.4 (LTS kernel) and 5.10 (most current kernel).
-
-Ebuild files end with `.ebuild` and contain a package’s dependencies - both build and runtime - as well as implement callbacks for various build steps, written in shell. The Gentoo package system calls those e.g. for fetching sources (`src_fetch()`) or for compiling the package (`src_compile()`). To make code reusable, Gentoo supports the concept of classes (in `eclass/`), which allow package ebuild files to inherit common base functions.
-
-Multiple ebuild trees can be stacked on “overlays”, allowing custom extensions or even custom sub-trees. In these stacks, “upper” level ebuilds override “lower” level ones. The Flatcar build system uses a fork of Gentoo upstream’s [portage-stable](https://github.com/flatcar-linux/portage-stable) as its base, and the overlay repository [coreos-overlay](https://github.com/flatcar-linux/coreos-overlay) for Flatcar specific modifications and packages on top.
-
-For more information on Gentoo in general please refer to the [Gentoo devmanual](https://devmanual.gentoo.org/).
-
-
-### Get to know the SDK chroot
-
-When entering the SDK you are in the `~/trunk/src/scripts` repository which can be seen as the build system.
-It is one of the three repositories that define a Flatcar build:
-1. flatcar-scripts (the directory you're in) contains high-level build scripts to build all packages for an image, to build an image, and to bootstrap an SDK.
-2. `~/trunk/src/third_party/portage-stable` contains ebuild files of all packages close to (or identical to) Gentoo upstream.
-3. `~/trunk/src/third_party/coreos-overlay` contains Flatcar specific packages like ignition and mayday, as well as Gentoo packages which were significantly modified for Flatcar.
-
-The SDK chroot you just entered is self-sustained and has all necessary "host" binaries installed to build Flatcar packages. Flatcar OS image packages are "cross-compiled" (even when host machine equals target machine, e.g. building an x86 image on an x86 host). The OS image packages have their own root within the SDK - `/build/amd64-usr/` for x86_64 and `/build/arm64-usr/` for ARM64, depending on which _board_ you initialised (see below).
-
-In other words, you'll be dealing with two levels of chroot:
-* The top-level SDK chroot, activated by `cork enter`, consisting of the build chroot with ebuild file sources (`src/` in the SDK directory) mounted in
-* The image chroot, in `/build/<arch>` in the SDK
-
-Both chroots use Gentoo's portage to manage the packages: `sudo emerge` is used to manage SDK packages, and `emerge-<arch>` (`emerge-amd64-usr` or `emerge-arm64-usr`, without sudo) is used to do the same for the OS image roots.
-
-#### Select the architecture to build
-
-`amd64-usr` and `arm64-usr` are the only targets supported by Flatcar.
-When setting up a new build target you can select it as default architecture, otherwise you need to specify the architecture for each step.
-The `--board` option can be set to one of a few known target architectures, or system "boards", to build for a given CPU.
-
-#### 64 bit AMD: The amd64-usr target
-
-AMD64 / x86_64 is well supported and is recommended for engineers getting started with Flatcar development.
-
-To initialise an AMD64 board chroot (`amd64-usr` in Flatcar lingo) in the directory `/build/amd64-usr/`, run:
+The container uses the "sdk" user (user and group ID are updated on container entry to match the host user's UID and GID).
+After entering you're put right into the (host) script repository's bind mount root.
+By default, the name of the container contains SDK and OS image version.
+After starting, the version file will have been updated:
 
 ```shell
-$ ./setup_board [--default] --board=amd64-usr
+sdk@flatcar-sdk-all-3066_0_0_os-alpha-3066_0_0-5-gcf4ff44a ~/trunk/src/scripts $ cat sdk_container/.repo/manifests/version.txt
+FLATCAR_VERSION=3066.0.0+5-gcf4ff44a
+FLATCAR_VERSION_ID=3066.0.0
+FLATCAR_BUILD_ID="5-gcf4ff44a"
+FLATCAR_SDK_VERSION=3066.0.0
 ```
 
-The `--default` flag makes this architecture the default so you don't need to specify `--board` when buidling packages and images.
+We're basing our work on release 3066.0.0 in this example, the current branch has 5 patches on top of that release, and the latest patch has the shortlog hash `cf4ff44a`.
+This leads to `FLATCAR_BUILD_ID` being set (to the output of `git describe --tags`) and is reflected in the container name `...os-alpha-3066_0_0-5-gcf4ff44a`.
 
-##### 64 bit ARM: The arm64-usr target
 
-ARM64 support is experimental and only recommended for advanced users.
+#### A note on persistence
 
-The SDK runs on an amd64 host system, relying on cross-compilation to create arm64 binaries.
-Still, during the compilation phase many package builds perform `configure` tests by running a compiled binary or invoke compiled helper binaries.
-This requires the host system to use binary translation (software-based virtualisation) for seamlessly running arm64 binaries.
+`run_sdk_container` re-uses containers once started; containers to be re-used are identified by name (see above). 
+Persistence helps with keeping changes in your work environment across container runs.
+**Keep in mind though that a new container will be created if the working commit in the scripts repository changes**.
+This is usually derired to prevent version muddling.
+It can be explicitly overridden by using the `-n <name>` argument to `run_sdk_container`.
 
-On a Fedora/Debian host system there is a `qemu-user-static` package that sets everything up.
-If you have troubles or use a different host system, check that a statically compiled aarch64 qemu-user binary is referenced with the `:F` flag for pinning it into the kernel so that it is not needed in every chroot:
 
+## Building an OS image
+
+<table><tr><td>
+
+**tl;dr** Build packages, base image, and vendor (qemu launchable) image.
+This builds for the default architecture, `amd64-usr`.
+Use `--board=arm64-usr` with packages / image script to build for ARM64.
+```shell
+sdk@flatcar-sdk $ ./build_packages
+sdk@flatcar-sdk $ ./build_image
+sdk@flatcar-sdk $ ./image_to_vm.sh <path-to-image--see-output-of-build_image>
+```
+
+</td></tr></table>
+
+Before we discuss any modifications to the image, we'll do a full image build first. This will create a "known-good" base to mount your changes on.
+
+### Select the target architecture
+
+At the time of writing the SDK supports two target architectures: AMD64 (x86-64) and ARM64.
+The target architecture can be specified by use of the `--board=` parameter to both `build_packages` and `build_image`:
+* `--board=amd64-usr` will build an x86 image
+* `--board=arm64-usr` will build and ARM64 image
+
+If no architecture is specified then AMD64 will be used by default.
+
+**NOTE** if you are cross-compiling make sure to set up qemu via binfmt-misc on your host machine:
 ```shell
 $ cat /usr/lib/binfmt.d/qemu-aarch64-static.conf
 :qemu-aarch64:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:F
@@ -228,28 +189,19 @@ $ sudo systemctl restart systemd-binfmt.service
 
 You can run `docker run --rm -ti arm64v8/alpine` on your host system as an easy check to verify everything is ready.
 
-In the SDK, to initialise an ARM64 / AARCH64 board chroot (`arm64-usr` in Flatcar lingo) in the directory `/build/amd64-usr/`, run:
+### Build the OS image packages
 
-```shell
-$ ./setup_board [--default] --board=arm64-usr
-```
-
-The SDK will set up the `QEMU_LD_PREFIX` environment variable, allowing to run any binaries under `/build/arm64-usr/`, without an additional `chroot` command.
-
-### Build all packages that make up the OS image
-
-Before we discuss any modifications to the image, we'll do a full image build first. This will create a "known-good" base to mount your changes on.
-
-First, build all of the target binary packages:
+It's likely this won't *actually* build the packages but rather download pre-built packages from the Flatcar binary package cache.
+The package cache is updated on every release.
 
 ```shell
 $ ./build_packages [--board=...]
 ```
 
-You only need to use `--board` if you did not use the `--default` option with `setup_board` above, or if you want to build for an architecture that's not your default one.
-The command should download most packages from our binary cache - speeding up the "build" - since we are basing this on an existing release. All packages will be installed to `/build/<arch>`.
+The command should download most packages from our binary cache - speeding up the "build" - since we are basing this on an existing release.
+All packages will be installed to `/build/<arch>`.
 
-You can also rebuild individual packages manually by running `emerge-<arch>-usr PACKAGE`, e.g. `emerge-amd64-usr vim`. In this case, no binary cache will be used and the package will always be rebuilt. 
+You can rebuild individual packages by running `emerge-<arch>-usr PACKAGE`, e.g. `emerge-amd64-usr vim`. In this case, no binary cache will be used and the package will always be rebuilt. 
 
 ### Create the Flatcar Container Linux OS image
 
@@ -269,6 +221,9 @@ $ ./image_to_vm.sh --from=../build/images/arm64-usr/developer-latest [--board=..
 
 For other vendor images, pass the `--format=` parameter (see `./image_to_vm.sh --help`).
 In general, `image_to_vm.sh` will read the generic disk image, install any vendor specific tools to the OEM partition where applicable (e.g. Azure VM tools for the Azure VM), and produce a vendor specific image. In the case of QEMU, a qcow2 image is produced. QEMU does not require vendor specific tooling in the OEM partition.
+
+On the host outside the container, the image(s) built are located in `__build__/images/...`.
+This directory is also bind-mounted into the container by `run_sdk_container`.
 
 ### Booting
 
@@ -298,48 +253,132 @@ You can log in via SSH keys or with a different ssh port by running this example
 
 Now for the interesting part! We are going to discuss 2 ways of making changes: adding or upgrading a package, and modifying the kernel configuration.
 
-### Add (or update) a package
+### A brief introduction to Gentoo how it relates to the SDK
 
-Let’s add a new package to our custom image. We’ll use a package already available in Gentoo upstream, add it to our SDK, chase down dependencies, and add those, too. Updating a package follows the same process - but instead of adding whole packages, new versions’ ebuild files are added to existing ones. Note that adding a package “from scratch” (including dependencies) which is not available via upstream is a completely different kind of beast and requires experience with both Gentoo as well as with fixing build and toolchain issues - so we're not going to discuss that here.
+Flatcar Container Linux is based on ChromiumOS, which is based on Gentoo.
+While the ChromiumOS heritage has faded and is barely visible nowadays, we heavily leverage Gentoo processes and tools.
 
-To get access to a rich and up-to-date selection of packages, we’ll use the upstream Gentoo ebuilds repository. We’ll copy the ebuild file of the package we want to add from upstream gentoo to portage-stable, as well as the package’s dependencies.
+Contrary to traditional Linux distributions, Gentoo applications and “packages” are compiled at installation time.
+Gentoo itself does not ship packages - instead, it consists of a massive number of ebuild files to build applications at installation time (that’s an oversimplification as there are binary package caches, but that’s beyond the scope of this document).
+While the Flatcar SDK can be understood as a Gentoo derivate, the OS image is special.
+The OS image is not self-contained, i.e. it cannot install / update packages - it lacks both a compiler to build packages as well as tools to orchestrate builds and install the resulting binaries.
+Instead, OS images are built via the SDK, by building packages in the SDK, then installing the binaries into a chroot environment.
+From the chroot environment, the resulting OS image is generated.
 
-Let’s start by checking out the Gentoo upstream ebuilds to some place outside the SDK. We’ll only do a shallow clone to limit the amount of data we need to download:
+Packages in Gentoo are organised in a flat hierarchy of `<group>/<package>/`.
+For instance, Linux kernel related ebuilds are in the group `sys-kernel` (kernel sources, headers, off-tree modules, etc.), while mail clients like thunderbird or mutt are in group `mail-client`.
+Each package directory may contain ebuild files for multiple versions, e.g. `dev-lang/python` contains a host of python versions (used in the SDK).
+Furthermore, each package directory contains a `Manifest` file with cryptographic checksums and file sizes of the package's source tarball(s), and may contain a `files/` directory containing auxiliary files to build / install the package, e.g. patches or config files.
+
+Multiple package sources - in separate directories - can be stacked on top of each other.
+These “overlays” allow custom extensions or even custom sub-trees on top of an existing foundation.
+In these stacks, “upper” level packages override “lower” level ones.
+The Flatcar build system uses a fork of Gentoo upstream’s [portage-stable](https://github.com/flatcar-linux/portage-stable) as its base, and the overlay repository [coreos-overlay](https://github.com/flatcar-linux/coreos-overlay) for Flatcar specific modifications and packages on top.
+
+Packages are built using "ebuild" files.
+These files contain a package’s dependencies - both build and runtime - as well as implement callbacks for downloading, patching, building, and installing a package.
+The callbacks in these ebuild files are written in shell.
+The Gentoo package system - portage - will, when building / installing a package, run the respective callbacks in order (e.g. `src_fetch()` for downloading package sources, and `src_compile()` for building).
+Common ebuild functions shared across many packages are implemented via classes (in `eclass/`) which can be inherited by package ebuilds.
+
+
+For more information on Gentoo in general please refer to the [Gentoo devmanual](https://devmanual.gentoo.org/).
+
+
+### Get to know the SDK chroot
+
+When entering the SDK you are in the `~/trunk/src/scripts` repository which can be seen as the build system.
+It is one of the three repositories that define a Flatcar build:
+1. flatcar-scripts (the directory you're in) contains high-level build scripts to build all packages for an image, to build an image, and to bootstrap an SDK.
+2. `~/trunk/src/third_party/portage-stable` contains ebuild files of all packages close to (or identical to) Gentoo upstream.
+3. `~/trunk/src/third_party/coreos-overlay` contains Flatcar specific packages like ignition and mayday, as well as Gentoo packages which were significantly modified for Flatcar, like the Linux kernel, or systemd.
+
+The SDK chroot you just entered is self-sustained and has all necessary "host" binaries installed to build Flatcar packages.
+Flatcar OS image packages are "cross-compiled" even when host machine equals target machine, e.g. building an x86 image on an x86 host.
+Cross-compiling via Gentoo's "crossdev" environment allows us to install packages in a chroot, which then can be used to build the OS image from.
+The OS image packages therefore have their own root inside the SDK - AMD64 is located at `/build/amd64-usr/` and ARM64 is under `/build/arm64-usr/`.
+
+Both board chroot and SDK use Gentoo's portage to manage its respective packages: `sudo emerge` is used to manage SDK packages, and `emerge-<arch>` (`emerge-amd64-usr` or `emerge-arm64-usr`, without sudo) is used to do the same for the OS image roots.
+
+
+## Add (or update) a package
+
+All of the following is done inside the SDK container, i.e. after running
 ```shell
-$ git clone --depth 5 https://anongit.gentoo.org/git/repo/gentoo.git
+$ ./run_sdk_container.sh -t
+```
+
+<table><tr><td>
+
+**tl;dr** In the SDK container, introduce a new upstream package from Gentoo.
+```shell
+~/trunk/src/scripts $ git clone --depth 5 https://github.com/gentoo/gentoo.git
+~/trunk/src/scripts $ mkdir -p ../third_party/portage-stable/<group>/
+~/trunk/src/scripts $ cp -R gentoo/<group>/<package> ../third_party/portage-stable/<group>/
+~/trunk/src/scripts $ emerge-amd64-usr --newuse <group>/<package>
+# optional - add missing eclass
+~/trunk/src/scripts $ cp gentoo/eclass/<eclass-name>.eclass ../third_party/portage-stable/eclass/
+~/trunk/src/scripts $ emerge-amd64-usr --newuse <group>/<package>
+# optional - unmask package
+~/trunk/src/scripts $ vim ../third_party/portage-stable/<group>/<package>/<package-version>.ebuild
+# remove '~' from arm64 and amd64
+~/trunk/src/scripts $ emerge-amd64-usr --newuse <group>/<package>
+# optional - add missing dependencies, see line 2 ff. above
+~/trunk/src/scripts $ ./build_image
+~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --format qemu
+~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
+~/trunk/src/scripts $ ssh core@localhost -p 2222
+# run new software to verify it works
+core@localhost ~ $ ...
+```
+
+</td></tr></table>
+
+Let’s add a new package to our custom image.
+We’ll use a package already available in Gentoo upstream, add it to our SDK, chase down dependencies, and add those, too.
+Updating a package follows the same process - but instead of adding whole packages, new versions’ ebuild files are added to existing ones.
+Note that adding a package “from scratch” - i.e. with no ebuild available via upstream is a completely different kind of beast and requires experience with both Gentoo as well as with fixing build and toolchain issues - so we're not going to discuss that here.
+
+To get access to a rich and up-to-date selection of packages, we’ll use the upstream Gentoo ebuilds repository.
+We’ll copy the ebuild file of the package we want to add from upstream gentoo to portage-stable, as well as the package’s dependencies.
+
+Let’s start by checking out the Gentoo upstream ebuilds to some place outside the SDK.
+We’ll only do a shallow clone to limit the amount of data we need to download:
+```shell
+~/trunk/src/scripts $ git clone --depth 5 https://github.com/gentoo/gentoo.git
 ```
 
 This gives us ~170 groups with a total of ~20,000 packages to pick from.
 
-Browse the Gentoo packages and find the one you want to add, or - in case of package updates - the newer version's `.ebuild` file of the package you want to update. Copy the whole package directory (including all upstream ebuilds and supplemental files, like patches) into the SDK’s `portage-stable/` directory, and create the group directory in `portage-stable/` if the group is not present yet. In the case of a package update, copy the new version's ebuild file to either `coreos-overlay` or `portage-stable`, depending on where the package to be upgraded resides. 
+Browse the Gentoo packages and find the one you want to add, or - in case of package updates - the newer version's `.ebuild` file of the package you want to update.
+Create the respective group directory in `~/trunk/src/third_party/portage-stable/` if it does not exist.
+Then copy the whole package directory (including all upstream ebuilds and supplemental files, like patches) into the SDK’s `portage-stable/` directory.
+
+In the case of a package update, copy the new version's ebuild file to either `coreos-overlay` or `portage-stable`, depending on where the package to be upgraded resides.
+Then add the newer version’s tarball checksum from the Gentoo package's `Manifest` file to the one in `portage-stable`.
 
 ```shell
-$ mkdir -p <flatcar-SDK>/src/third_party/portage-stable/<group>/
-$ cp -R <gentoo-repo-dir>/<group>/<package> <flatcar-SDK>/src/third_party/portage-stable/<group>/
+~/trunk/src/scripts $ mkdir -p <flatcar-SDK>/src/third_party/portage-stable/<group>/
+~/trunk/src/scripts $ cp -R <gentoo-repo-dir>/<group>/<package> <flatcar-SDK>/src/third_party/portage-stable/<group>/
 ```
-If you just want to upgrade a package by adding the ebuild file of a newer version, don’t forget to add the newer version’s tarball checksum for Gentoo’s `Manifest` file to `portage-stable`’s.
 
-The next step will have us add all required dependencies for the new package. This usually is not necessary for package upgrades. We will try to build the new / upgraded package, chase down all of the dependencies, and likewise copy those to the respective `<flatcar-SDK>/src/third_party` folder, too. Depending on the gentoo classes inherited by the new package’s ebuild file, we might need to copy .eclass files, too.
+The next step will have us add all required dependencies for the new package.
+This usually is not necessary for package upgrades.
+We will try to build the new / upgraded package, chase down all of the dependencies, and likewise copy those to the respective `<flatcar-SDK>/src/third_party` folder, too.
+Depending on the gentoo classes inherited by the new package’s ebuild file, we might need to copy .eclass files, too.
 
 So let’s enter the SDK chroot and try to build and install:
 ```shell
-$ emerge-amd64-usr --newuse <group>/<package>
+~/trunk/src/scripts $ emerge-amd64-usr --newuse <group>/<package>
 ```
 
-If you see walls of error output that contain lines like `[XXXXX].eclass could not be found by inherit()` then we need to copy the respective `.eclass` file. It means that the ebuild of the package we are trying to add contains in its `inherit` line an eclass which is not present in our SDK’s portage-stable. eclasses exist to prevent code duplication; ebuild files can “inherit” common callback implementations e.g. for fetching, configuring, and compiling sources from these base classes. Copy all required eclasses:
+If you see walls of error output that contain lines like `[XXXXX].eclass could not be found by inherit()` then we need to copy the respective `.eclass` file.
+It means that the ebuild of the package we are trying to add contains in its `inherit` line an eclass which is not present in our SDK’s portage-stable.
+So let's copy the missing eclass:
 ```shell
-$ cp <gentoo-repo-dir>/eclass/[XXXXX].eclass <flatcar-SDK>/src/third_party/portage-stable/eclass/
+~/trunk/src/scripts $ cp <gentoo-repo-dir>/eclass/[XXXXX].eclass <flatcar-SDK>/src/third_party/portage-stable/eclass/
 ```
-until the errors go away.
-
-Also, you may encounter errors like `Invalid implementation in PYTHON_COMPAT: python3_8` which implies that the ebuild declares compatibility to python version 3.8, which is not (yet) available in the SDK. To mitigate, edit the new package’s `.ebuild` file, find the line 
-```shell
- PYTHON_COMPAT=( python3_{6,7,8} )
-```
-And remove the “,8”:
-```shell
- PYTHON_COMPAT=( python3_{6,7} )
-```
+and re-run emerge. Repeat with other missing classes until the errors go away.
 
 Lastly, the SDK might lack unmasks if the respective architecture is masked in the upstream ebuild of the package(s) added (i.e. the `KEYWORDS` variable contains `"... ~amd64 ~arm64 ... "`). Gentoo upstream uses these masks to mark a package as experimental. If that’s the case then emerge will fail with an error like
 ```shell
@@ -348,19 +387,9 @@ Lastly, the SDK might lack unmasks if the respective architecture is masked in t
   # required by =<group>/package> (argument)
   =<other-group>/<other-package> **
 ```
-The keywords and unmasks can be added automatically to your local SDK by running
-```shell
-$  emerge-amd64-usr --newuse <group>/<package> --autounmask=y --autounmask-write --ask
-```
 
-which will print the changes and prompt you before writing them. Run `emerge-amd64-usr --newuse <group>/<package>` again to proceed.
-
-**NOTE**: a bug in the Chromium part of the SDK will lead to the following warning:
-```shell
---- Invalid atom in /build/amd64-usr/etc/portage/package.unmask/cros-workon:
-     =<group>/<package>
-```
-The SDK creates softlinks for both `/build/amd64-usr/etc/portage/package.unmask/cros-workon` and `/build/amd64-usr/etc/portage/package.keywords/cros-workon` to the same file - to `.config/cros_workon/amd64-usr` (outside the SDK chroot). This effectively merges all required keywords and unmasks into the same file. The keywords and unmasks files follow different semantics, leading to emerge printing the warning above. Since invalid atoms will be ignored, it’s safe to ignore the warning for the time being.
+To proceed, remove the architecture mask in the ebuild file (remove the `~` - for example, change `~arm64` to `arm64`) and re-run emerge.
+FLatcar follows its own stabilisation process (through the Alpha - Beta - Stable channels); it's perfectly fine to unmask a package upstream considers unstable.
 
 If you want to use optional build flags (USE flags in Gentoo lingo) e.g. for compiling optional library support into the application, add the new package and the respective USE flag(s) to `src/third_party/portage-stable/profiles/base/package.use`.
 
@@ -371,141 +400,211 @@ emerge: there are no ebuilds to satisfy "<group>/<package>:=" for /build/amd64-u
 
 For each of those missing dependencies, repeat the process of adding a package described above.
 
-Of course, the missing dependencies can also have missing dependencies on their own. Or missing `.eclass` files. Or referencing a python version not in the SDK. Or are in need of more keywords / unmasks. Worry not, just keep iterating, things will work eventually.
+Of course, the missing dependencies can also have missing dependencies on their own.
+Or missing `.eclass` files.
+Or are in need of more keywords / unmasks.
+Worry not, just keep iterating, things will work eventually.
 
 
-##### Rebuild the image
+### Rebuild the image
 
-After we’ve successfully built and packaged (calling `emerge` without parameters does both) it’s time to create a new OS image to validate whether the new addition works as intended. We’ll first generate an image from our workspace (where we built a "stock" image successfully already) to make sure the new addition does not cause file conflicts with other packages, and to be able to validate the new software works as intended. After that, we’ll purge everything we’ve built, then rebuild the image from scratch.
+After we’ve successfully built and packaged (calling `emerge` without parameters does both) it’s time to create a new OS image to validate whether the new addition works as intended.
+We’ll first generate an image from our workspace (where we built a "stock" image successfully already) to make sure the new addition does not cause file conflicts with other packages, and to be able to validate the new software in a live system.
 
-First, we add the new package to the base image packages list. The list of packages for the base image is an ebuild file itself - and the packages list is just a list of dependencies in that ebuild. Let’s add the package: 
+First, we add the new package to the base image packages list.
+The list of packages for the base image is an ebuild file itself - and the packages list is just a list of dependencies in that ebuild.
+Let’s add the package: 
 ```shell
-$ cork enter
-$ vim ../third_party/coreos-overlay/coreos-base/coreos/coreos-0.0.1.ebuild
+~/trunk/src/scripts $ vim ../third_party/coreos-overlay/coreos-base/coreos/coreos-0.0.1.ebuild
 ```
 In Vim, add `<group>/<package>` to list of packages in `RDEPENDS="..."`.
 
-If you were required to add unmasks for the new package(s) to your local SDK via `--autounmask-write`, make sure to add the package version to `../third_party/portage-stable/profiles/base/package.accept_keywords` in the format `=<group>/<package>-<version> ~amd64 ~arm64`. 
-
-Now we’ll rebuild the OS image from the updated list of packages, then run it in qemu. This will allow us to validate whether the new package works correctly:
+Now we’ll rebuild the OS image from the updated list of packages, then run it in qemu.
+This will allow us to validate whether the software added works to our expectations:
 ```shell
-$ ./build_image --board=amd64-usr
-$ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-$ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
-$ ssh core@localhost -p 2222
+~/trunk/src/scripts $ ./build_image
+~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --format qemu
+~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
+~/trunk/src/scripts $ ssh core@localhost -p 2222
+core@localhost ~ $ ...
 ```
 
-Now try commands from the package you added and make sure they work, or check the presence of files (e.g. new libraries). If something is wrong (e.g. config files are missing etc.), go back and e.g. change the application ebuild accordingly, addressing the errors you’ve observed. Then `emerge` the application once more to force re-packaging, and rebuild the image and test again. Should you run into “no space left on device” issues when building the image, you will need to increase the size of the USR1 and USR2 partitions in `build_library/disk_layout.json`.
+Now try commands from the package you added and make sure they work, or check the presence of files (e.g. new libraries).
+If something is wrong (e.g. config files are missing etc.), go back and e.g. change the application ebuild accordingly, addressing the errors you’ve observed.
+Then `emerge` the application once more to force re-packaging, and rebuild the image and test again.
 
-Finally, we want to perform a scratch build to make sure your change is reproducible and did not break pristine builds. For this, reinitialise the board (which will purge everything we’ve built and all binary packages downloaded for the image) and rebuild the OS image from scratch:
+## Change the kernel configuration / add or remove a kernel module
+
+All of the following is done inside the SDK container, i.e. after running
 ```shell
-$ ./setup_board --board=amd64-usr --force
-$ ./build_packages --board=amd64-usr
-$ ./build_image --board=amd64-usr
+$ ./run_sdk_container.sh -t
 ```
 
-### Change the kernel configuration / add or remove a kernel module
+<table><tr><td>
 
-Next, we’ll look into changing the kernel configuration - e.g. for adding a kernel module or a core kernel feature not shipped with stock Flatcar. This will give you a low level deep dive into the Gentoo build system.
+**tl;dr** In the SDK container, build the kernel package with a custom config, run+test, and persist
+```shell
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild configure
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild compile
+~/trunk/src/scripts $ cd /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-kernel-<version>/work/coreos-kernel-<version>/build
+<build-temp-directory> $ cp .config ~/trunk/src/scripts/kernel-config.orig
+<build-temp-directory> $ make menuconfig
+<build-temp-directory> $ cp .config ~/trunk/src/scripts/kernel-config.mine
+<build-temp-directory> $ cd ~/trunk/src/scripts/
+~/trunk/src/scripts $ rm /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-kernel-<version>/.compiled
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild compile
+~/trunk/src/scripts $ sed -i 's/^CONFIG_INITRAMFS_SOURCE=.*//' kernel-config.mine
+~/trunk/src/scripts $ rm -rf /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-modules-<version>
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild unpack
+~/trunk/src/scripts $ cp kernel-config.mine /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-modules-<version>/work/coreos-modules-<version>/build/.config
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild compile
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild package
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild package
+~/trunk/src/scripts $ ./build_image --board=amd64-usr
+~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
+~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
+~/trunk/src/scripts $ ssh core@localhost -p 2222
+core@localhost ~ $ ...
 
-Our first step is to set you all up with a pre-configured stock Flatcar Linux kernel to base your modifications on. The Flatcar Linux kernel build is split over multiple gentoo ebuild files which all reside in <code>[coreos-overlay/sys-kernel/](https://github.com/kinvolk/coreos-overlay/tree/main/sys-kernel)</code>:
+~/trunk/src/scripts $ diff kernel-config.orig kernel-config.mine > ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/my.diff
+~/trunk/src/scripts $ cd ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/
+~/trunk/src/scripts $ vim -O commonconfig* amd64_defconfig* my.diff
+~/trunk/src/scripts $ rm my.diff
+~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-kernel
+~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-modules
+~/trunk/src/scripts $ ./build_image --board=amd64-usr
+~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
+~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+~/trunk/src/scripts $ ssh core@localhost -p 2222
+
+~/trunk/src/scripts $ diff kernel-config.orig kernel-config.mine > ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/my.diff
+~/trunk/src/scripts $ cd ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/
+~/trunk/src/third_party/coreos-overlay/sys-kernel/coreos-modules/files/ $ vim -O commonconfig* amd64_defconfig* my.diff
+~/trunk/src/third_party/coreos-overlay/sys-kernel/coreos-modules/files/ $ rm my.diff
+
+~/trunk/src/scripts $ cd ~/trunk/src/scripts 
+~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-kernel
+~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-modules
+~/trunk/src/scripts $ ./build_image --board=amd64-usr
+~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
+~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+~/trunk/src/scripts $ ssh core@localhost -p 2222
+```
+
+</td></tr></table>
+
+Next, we’ll look into changing the kernel configuration - e.g. for adding a kernel module or a core kernel feature not shipped with stock Flatcar.
+This will give you a deep dive into the low-level bits of Gentoo's build and packaging system.
+To modify the configuration of a package we will run its individual build steps manually - by use of `ebuild` instead of `emerge`.
+This will allow for pausing after downloading the sources, to change the source tree configuration before building and installing.
+
+Our first step is to set you all up with a pre-configured stock Flatcar Linux kernel to base your modifications on.
+The Flatcar Linux kernel build is split over multiple gentoo ebuild files which all reside in <code>[coreos-overlay/sys-kernel/](https://github.com/kinvolk/coreos-overlay/tree/main/sys-kernel)</code>:
 
 *   `coreos-sources/` for pulling the kernel sources from git.kernel.org
 *   `coreos-kernel/` for building the main kernel (vmlinuz)
 *   `coreos-modules/` for building the modules, and - somewhat counterintuitively - containing all kernel config files. The kernel configuration in `coreos-modules/files/` is split into 
     *   a platform independent part  - `commonconfig-<version>`
     *   platform dependent configs - `<arch>_defconfig-<version>`
+**NOTE** that these configuration snippets do not contain the whole kernel config but only Flatcar specific ones.
+During the build process the config snippets are merged with the kernel's defaults for all the settings not covered by our snippets, via `make oldconfig`.
 
-The first section below will elaborate on developing, and testing, your modifications before we’ll merge into the ebuilds mentioned above. To achieve this, we will use the low level `ebuild` tool to selectively prepare the build of kernel image and modules, then make our modifications in Gentoo’s temporary build directories, and then continue the build. This way we’ll arrive at a boot-able, test-able image before merging your changes into the coreos-overlay ebuild file. Using Gentoo’s build-temp directories will also allow you to better iterate on your changes if you encounter problems during the build, or when testing your changes in a qemu image.
+The first section below will elaborate on developing and testing your modifications via Portage's temporary build directory before we’ll merge into the ebuilds mentioned above.
+This way we’ll arrive at a boot-able, test-able image before merging your changes into the coreos-overlay ebuild file.
+Using Gentoo’s build-temp directories will also allow you to better iterate on your changes if you encounter problems during the build, or when testing your changes in a qemu image.
 
-Only after we’ve tested our changes will we modify the kernel ebuild to persist the new configuration.
+Only after we’ve tested our changes will we modify the kernel ebuild in `coreos-overlay` to persist the new configuration.
 
 First, we will set up kernel and module sources, and modify those before build. To fetch and to configure the sources and to build a stock kernel, run:
 ```shell
-$ cork enter
-$ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild configure
-$ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild compile
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild configure
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild compile
 ```
 
-The tool we just used - `ebuild` - is a low-level tool and part of the Gentoo package ecosystem. It is used by the higher level `emerge` tool for fetching, building, and installing source packages. A single `emerge` call runs `ebuild fetch, unpack, compile, install, merge, package`. Using `ebuild` instead of emerge (like above) allows us to stop the installation process after the package sources are configured, edit the sources, and then continue with the installation. Let’s cd to the configured kernel source tree in Gentoo’s temporary build directory:
+`ebuild` is a low-level tool and part of the Portage ecosystem.
+It is used by the higher level `emerge` tool for fetching, building, and installing source packages.
+A single `emerge` call runs `ebuild fetch, unpack, compile, install, merge, package`.
+Using `ebuild` instead of emerge allows us to stop the installation process after the package sources are configured, edit the sources, and then continue with the installation.
+Let’s cd to the configured kernel source tree in Gentoo’s temporary build directory:
 ```shell
-$ cd /build/amd64-usr/var/tmp/portage/sys-kernel/
-$ cd coreos-kernel-<version>/work/coreos-kernel-<version>/build
+~/trunk/src/scripts $ cd /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-kernel-<version>/work/coreos-kernel-<version>/build
 ```
 
 Before we introduce our modifications we’ll make a copy of the original config:
 ```shell
-$ cp .config ~/trunk/src/scripts/kernel-config.orig
+<build-temp-directory> $ cp .config ~/trunk/src/scripts/kernel-config.orig
 ```
 
 The kernel’s menuconfig is a nice way to review the configuration as well as to make changes:
 ```shell
-$ make menuconfig
+<build-temp-directory> $ make menuconfig
 ```
 
 Make your changes, save the new configuration, and copy the resulting `.config` to `scripts/`:
 ```shell
-$ cp .config ~/trunk/src/scripts/kernel-config.mine
+<build-temp-directory> $ cp .config ~/trunk/src/scripts/kernel-config.mine
 ```
 
 Back in `~/trunk/src/scripts/`, rebuild the kernel image:
 ```shell
-$ cd ~/trunk/src/scripts/
-$ rm /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-kernel-<version>/.compiled
-$ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild compile
+<build-temp-directory> $ cd ~/trunk/src/scripts/
+~/trunk/src/scripts $ rm /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-kernel-<version>/.compiled
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild compile
 ```
 
-The kernel configuration will contain an auto-generated INITRAMFS line. This line must not be present in a pristine Flatcar kernel config (i.e. in an original ebuild config); there’s a sanity check in the module ebuild that will cause the module build to fail if that line is present. So we’ll remove it:
+The kernel configuration will contain an auto-generated INITRAMFS line.
+This line must not be present in a pristine Flatcar kernel config (i.e. in an original ebuild config); there’s a sanity check in the module ebuild that will cause the module build to fail if that line is present.
+So we’ll remove it:
 ```shell
-$ sed -i 's/^CONFIG_INITRAMFS_SOURCE=.*//' kernel-config.mine
+~/trunk/src/scripts $ sed -i 's/^CONFIG_INITRAMFS_SOURCE=.*//' kernel-config.mine
 ```
 
 Then delete the modules build directory - which we only needed above to get to a kernel .config - and fetch it anew, copy the kernel configuration, and rebuild the modules:
 ```shell
-$ rm -rf /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-modules-<version>
-$ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild unpack
-$ cp kernel-config.mine /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-modules-<version>/work/coreos-modules-<version>/build/.config
-$ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild compile
+~/trunk/src/scripts $ rm -rf /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-modules-<version>
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild unpack
+~/trunk/src/scripts $ cp kernel-config.mine /build/amd64-usr/var/tmp/portage/sys-kernel/coreos-modules-<version>/work/coreos-modules-<version>/build/.config
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild compile
 ```
 
-At this point, we have both a kernel build as well as kernel module binaries - but these are in temporary working directories. In order to be able to use those for an image build, we need to generate binary packages from what we compiled. All binary packages reside below `/build/amd64-usr/var/lib/portage/pkgs/`. In the next step, we’ll build `coreos-kernel-<version>.tbz2` and `coreos-modules-<version>.tbz2`, which will land in `/build/amd64-usr/var/lib/portage/pkgs/sys-kernel`.
+At this point, we have both a kernel build as well as kernel module binaries - but these are in temporary working directories.
+In order to be able to use those for an image build, we need to generate binary packages from what we compiled.
+All binary packages reside in the board chroot at `/build/amd64-usr/var/lib/portage/pkgs/`.
+In the next step, we’ll build `coreos-kernel-<version>.tbz2` and `coreos-modules-<version>.tbz2`, which will land in `/build/amd64-usr/var/lib/portage/pkgs/sys-kernel`.
 
 We package the kernel and kernel modules:
 ```shell
-$ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild package
-$ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild package
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-<version>.ebuild package
+~/trunk/src/scripts $ ebuild-amd64-usr ../third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-<version>.ebuild package
 ```
 
 These packages can now be picked up by the image builder script. Let’s build a new image and boot it with qemu - this will allow us to validate the changes we made to the kernel config before persisting: 
 ```shell
-$ ./build_image --board=amd64-usr
-$ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-$ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
-$ ssh core@localhost -p 2222
+~/trunk/src/scripts $ ./build_image --board=amd64-usr
+~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
+~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh &
+~/trunk/src/scripts $ ssh core@localhost -p 2222
 ```
 
 After we’ve verified that our modifications work as expected, let’s persist the changes into the ebuild file - in `sys-kernel/coreos-modules` (as previously mentioned).
-First, we’ll generate a diff between the original config and our own config. Then, we’ll open an editor and manually transfer the configuration changes.
+First, we’ll generate a diff between the original config and our own config.
+Then, we’ll open an editor and manually transfer the settings we actually changed - remember, the config snippets in `coreos-overlay` only contain Flatcar specifics.
 ```shell
-$ diff kernel-config.orig kernel-config.mine > ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/my.diff
-$ cd ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/
-$ vim -O commonconfig* amd64_defconfig* my.diff
-$ rm my.diff
+~/trunk/src/scripts $ diff kernel-config.orig kernel-config.mine > ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/my.diff
+~/trunk/src/scripts $ cd ../third_party/coreos-overlay/sys-kernel/coreos-modules/files/
+~/trunk/src/third_party/coreos-overlay/sys-kernel/coreos-modules/files/ $ vim -O commonconfig* amd64_defconfig* my.diff
+~/trunk/src/third_party/coreos-overlay/sys-kernel/coreos-modules/files/ $ rm my.diff
 ```
 
 Finally, we’ll rebuild kernel and modules using the updated ebuild, to make sure the build works:
 ```shell
-$ emerge-amd64-usr sys-kernel/coreos-kernel
-$ emerge-amd64-usr sys-kernel/coreos-modules
-$ ./build_image --board=amd64-usr
-$ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
-$ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
-$ ssh core@localhost -p 2222
+~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-kernel
+~/trunk/src/scripts $ emerge-amd64-usr sys-kernel/coreos-modules
+~/trunk/src/scripts $ ./build_image --board=amd64-usr
+~/trunk/src/scripts $ ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --format qemu
+~/trunk/src/scripts $ ../build/images/amd64-usr/latest/flatcar_production_qemu.sh
+~/trunk/src/scripts $ ssh core@localhost -p 2222
 ```
-
-## Tips and tricks
-
-We've compiled a [list of tips and tricks][sdktips] that can make working with the SDK a bit easier.
 
 
 ## Rebuilding the SDK
@@ -516,11 +615,16 @@ Take a look at the [SDK bootstrap process](sdk-bootstrapping) to learn how to bu
 
 [Mantle][mantle] is a collection of utilities used in testing and launching SDK images.
 
-[android-repo-git]: https://source.android.com/source/developing.html
 [flatcar-dev]: https://groups.google.com/forum/#!forum/flatcar-linux-dev
-[github-flatcar]: https://github.com/kinvolk/Flatcar
-[irc]: irc://irc.freenode.org:6667/#flatcar
-[mantle]: https://github.com/kinvolk/mantle
+[github-flatcar]: https://github.com/flatcar-linux
+[matrix]: https://app.element.io/#/room/#flatcar:matrix.org
+[ghcr-sdk]: https://github.com/orgs/flatcar-linux/packages
+[scripts]: https://github.com/flatcar-linux/scripts
+[flatcar-releases]: https://www.flatcar-linux.org/releases/
+
+
+[coreos]: https://github.com/flatcar-linux/coreos-overlay
+[portage]: https://github.com/flatcar-linux/portage-stable
+[mantle]: https://github.com/flatcar-linux/mantle
 [prodimages]: sdk-building-production-images
-[repo-blog]: http://google-opensource.blogspot.com/2008/11/gerrit-and-repo-android-source.html
 [sdktips]: sdk-tips-and-tricks

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -26,9 +26,14 @@ Please direct questions and suggestions to the [#flatcar:matrix.org Matrix chann
 ```shell
 $ git clone https://github.com/flatcar-linux/scripts.git
 $ cd scripts
-$ git checkout $(git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1) 
+$ branch="$(git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1)"
+$ git checkout "$branch"
 $ git submodule init
 $ git submodule update
+$ for s in sdk_container/src/third_party/coreos-overlay/ sdk_container/src/third_party/portage-stable; do
+$   git -C "$s" checkout "$branch"
+$   git -C "$s" pull --rebase
+$ done
 $ ./run_sdk_container -t
 ```
 
@@ -87,7 +92,7 @@ It is generally recommended to base work on the latest Alpha release.
 While new features should target `main` at merge time, Alpha is a tested release and therefore offers a more stable foundation to base work on.
 At the same time, Alpha is not too far away from `main` so the risk of merge-time conflicts should be low.
 
-Get the latest Alpha release branch:
+Find the latest Alpha release branch:
 
 ```shell
 $ git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1
@@ -95,14 +100,30 @@ $ git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -
 
 If the goal is to reproduce and to fix a bug of a release other than Alpha, it is recommended to base the work on the latest point release of the respective major version instead of Alpha. All currrently "active" major versions can be found at the top of the [releases][flatcar-releases] web page.
 
-Check out the branch and update the submodules:
+For quick reference, to get the latest stable release tag, use:
+```shell
+$ git tag -l | grep -E 'stable-[0-9.]+$' | sort | tail -n 1
+```
+(replace `stable` with `beta` or `alpha` in accordance with your needs).
+
+Now check out the tag or branch and update the submodules:
 
 ```shell
-$ git checkout [branch-from-above]
+$ git checkout [branch-or-tag-from-above]
 $ git submodule update
 ```
 
-To verify the version in use, consult the version file.
+**Note**: When using a branch, the submodule pinnings might be outdated, so it's always a good idea to pull the latest branch tips for the submodules, too.
+This is not an issue with release tags; a release tag always pins the submodule state at the point of release.
+
+```shell
+$ for s in sdk_container/src/third_party/coreos-overlay/ sdk_container/src/third_party/portage-stable; do
+$   git -C "$s" checkout [branch]
+$   git -C "$s" pull --rebase
+$ done
+```
+
+Lastly, to verify the version in use, consult the version file.
 This file is updated on each release and reflects the SDK and OS versions corresponding to the the current commit.
 
 ```shell

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -197,7 +197,7 @@ Before we discuss any modifications to the image, we'll do a full image build fi
 **NOTE on cross-compilation**: if you are cross-compiling make sure a static aarch64 qemu is set up via binfmt-misc on your host machine.
 Some packages compile and execute intermediate commands during their build process - this can break cross-compiling since the commands are built for the target architecture.
 The qemu binary on the host needs to be a static binary since it will be called from within the container context.
-Check if your distro has support for aarch64 in `binfmt-misc` already; on e.g. Fedora there's an `qemu-aarch64` entry in `/proc` for that (the name of the proc file may vary across distributions though):
+Check if your distro has a `qemu-user-static` package that you can install or whether it has support for aarch64 in `binfmt-misc` already; on e.g. Fedora there's an `qemu-aarch64` entry in `/proc` for that (the name of the proc file may vary across distributions though):
 ```shell
 $ cat /proc/sys/fs/binfmt_misc/qemu-aarch64
 enabled

--- a/docs/reference/developer-guides/sdk-tips-and-tricks.md
+++ b/docs/reference/developer-guides/sdk-tips-and-tricks.md
@@ -157,9 +157,9 @@ By default, the SDK container is re-used when using the `./run_sdk_container` sc
 To reset the container, list all docker containers:
 ```shell
 docker ps --all
-...
+…
 00a133b61c55   ghcr.io/flatcar-linux/flatcar-sdk-all:3087.0.0        "/bin/sh -c /home/sd…"   2 weeks ago   Exited (137) 11 days ago             flatcar-sdk-all-3087.0.0_os-alpha-3087.0.0-1-g39d915ae
-...
+…
 ```
 and identify the SDK / OS image release version you've been working on.
 Then delete the container:
@@ -291,4 +291,4 @@ e96281a6-d1af-4bde-9a0a-97b76e56dc57
 
 
 
-[mod-cl]: sdk-modifying-flatcar
+[mod-cl]: sdk-modifying-flatcar.md

--- a/docs/reference/developer-guides/sdk-tips-and-tricks.md
+++ b/docs/reference/developer-guides/sdk-tips-and-tricks.md
@@ -291,4 +291,4 @@ e96281a6-d1af-4bde-9a0a-97b76e56dc57
 
 
 
-[mod-cl]: sdk-modifying-flatcar.md
+[mod-cl]: sdk-modifying-flatcar

--- a/docs/reference/developer-guides/sdk-tips-and-tricks.md
+++ b/docs/reference/developer-guides/sdk-tips-and-tricks.md
@@ -96,7 +96,7 @@ References:
 
 Your SSH keys should be detected and added automatically by the image build process. Optionally, you can set a password for the `core` user which you can use later for ssh authentication, should SSH pubkey authentication not work for you.
 
-After entering the SDK container for the first time (or after re-creating it , you can set user `core`'s password:
+After entering the SDK container for the first time (or after re-creating it), you can set user `core`'s password:
 
 ```shell
 $ ./set_shared_user_password.sh


### PR DESCRIPTION
This PR updates the developer reference documentation to cover the SDK container.
It also repurposes the "building production images" document to discuss containerised builds and CI automation.