### PR TITLE
Add more info on the update.conf file and manual updates

### DIFF
--- a/docs/setup/releases/update-conf.md
+++ b/docs/setup/releases/update-conf.md
@@ -37,11 +37,12 @@ Default installs of Flatcar will likely not need custom settings, and an empty o
 
 * `GROUP`
   * The channel/group this host will pull updates from
-  * public channels will be: `stable`, `beta`, `alpha`
-  * otherwise these are UUIDs
+  * public channels will be: `stable`, `beta`, `alpha` - since this value is also part of the OS image under `/usr/share/flatcar/update.conf` you should only overwrite it if needed
+  * Nebraska supports group aliases that can be used instead of UUIDs
 * `SERVER`
   * The update server to reach for updates
   * default community server is: https://public.update.flatcar-linux.net/v1/update/
+  * An invalid URL like `disabled` will effectively disable downloading of updates while still allowing update-engine to mark a booted partition as successful, with the `flatcar-update` command you can use this instead of masking `update-engine.service`
 * `FLATCAR_RELEASE_VERSION`
   * The current version of this machine
 * `FLATCAR_RELEASE_BOARD`
@@ -58,7 +59,7 @@ Default installs of Flatcar will likely not need custom settings, and an empty o
   * Authentication password for fetching the update payload
   * As the update server can redirect to a payload download that may require its own authentication
 * `MACHINE_ALIAS`
-  * Optional human-friendly name for the machine in addition to the machine ID from `/etc/machine-id`, to be displayed in the update server UI, should be unique but this is not enforced
+  * Optional human-friendly name for the machine in addition to the machine ID from `/etc/machine-id`, to be displayed in the update server UI, should be unique but this is not enforced, use quotes if it contains whitespace
   * Set this dynamically by running, e.g., `sudo sed -i "/MACHINE_ALIAS=.*/d" /etc/flatcar/update.conf ;  echo "MACHINE_ALIAS=$(hostname)" | sudo tee -a /etc/flatcar/update.conf` for the output of the `hostname` command (as with the other variables, restarting `update-engine.service` is not needed)
 
 _(for future-proofing, calling `git grep GetConfValue\(\"` in the [`update_engine`][update_engine] repo)_


### PR DESCRIPTION
- setup/releases/update-conf: add more info on how to use the parameters
- setup/releases/update-strategies: document the flatcar-update tool    
    When automatic updates are disabled and the update should be done
    manually it helps to still use the flatcar-update tool as it handles
    the disabling of updates again at the right time.
    Document it as alternative to doing all steps manually.
