### PR TITLE
Use real OEM filesystem when specifying it

### DIFF
--- a/docs/installing/cloud/vmware.md
+++ b/docs/installing/cloud/vmware.md
@@ -289,7 +289,7 @@ storage:
     - name: oem
       mount:
         device: /dev/disk/by-label/OEM
-        format: ext4
+        format: btrfs
         label: OEM
   files:
     - path: /grub.cfg

--- a/docs/reference/developer-guides/sdk-disk-partitions.md
+++ b/docs/reference/developer-guides/sdk-disk-partitions.md
@@ -13,10 +13,10 @@ Flatcar Container Linux is designed to be reliably updated via a continuous stre
 |:------:|------------|-------------------------------------------------------------------|-----------------------|
 | 1      | EFI-SYSTEM | Contains the bootloader                                           | FAT32                 |
 | 2      | BIOS-BOOT  | Contains the second stages of GRUB for use when booting from BIOS | grub core.img         |
-| 3      | USR-A      | One of two active/passive partitions holding Flatcar Container Linux      | EXT4                  |
+| 3      | USR-A      | One of two active/passive partitions holding Flatcar Container Linux      | EXT2                  |
 | 4      | USR-B      | One of two active/passive partitions holding Flatcar Container Linux      | (empty on first boot) |
 | 5      | ROOT-C     | This partition is reserved for future use                         | (none)                |
-| 6      | OEM        | Stores configuration data specific to an [OEM platform][OEM docs] | EXT4                  |
+| 6      | OEM        | Stores configuration data specific to an [OEM platform][OEM docs] | BTRFS                 |
 | 7      | OEM-CONFIG | Optional storage for an OEM                                       | (defined by OEM)      |
 | 8      | (unused)   | This partition is reserved for future use                         | (none)                |
 | 9      | ROOT       | Stateful partition for storing persistent data                    | EXT4, BTRFS, or XFS   |

--- a/docs/setup/customization/other-settings.md
+++ b/docs/setup/customization/other-settings.md
@@ -99,7 +99,7 @@ storage:
     - name: "OEM"
       mount:
         device: "/dev/disk/by-label/OEM"
-        format: "ext4"
+        format: "btrfs"
   files:
     - filesystem: "OEM"
       path: "/grub.cfg"

--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -246,7 +246,7 @@ storage:
     - name: oem
       mount:
         device: /dev/disk/by-label/OEM
-        format: ext4
+        format: btrfs
         label: OEM
   directories:
   - path: /bin

--- a/docs/setup/security/disabling-smt.md
+++ b/docs/setup/security/disabling-smt.md
@@ -49,7 +49,7 @@ storage:
     - name: OEM
       mount:
         device: /dev/disk/by-label/OEM
-        format: ext4
+        format: btrfs
   files:
     - filesystem: OEM
       path: /grub.cfg


### PR DESCRIPTION
While we support passing ext4 as config entry for the OEM filesystem in
Ignition, this will be ignored since btrfs is used.
Update the docs to avoid any confusion.
While on it also fix the USR partition filesystem which is ext2, not  
ext4.


## How to use


## Testing done

