### PR TITLE
adding-swap: break dependencies cycle

### DIFF
--- a/docs/setup/storage/adding-swap.md
+++ b/docs/setup/storage/adding-swap.md
@@ -116,7 +116,7 @@ systemd:
         [Unit]
         Description=Create a swapfile
         RequiresMountsFor=/var
-        ConditionPathExists=!/var/vm/swapfile1
+        DefaultDependencies=no
 
         [Service]
         Type=oneshot


### PR DESCRIPTION
Service units as default dependencies to `sysinit.target`, this can
create a cycle since `create-swap.service` is required by
`var-vm-swapfile1.swap` and this is required by `swap.target` which is
required by `sysinit.target`.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
