### PR TITLE
Update ct container references to use ghcr

### DIFF
--- a/docs/installing/vms/libvirt.md
+++ b/docs/installing/vms/libvirt.md
@@ -142,7 +142,7 @@ Assuming that you save this as `example.yaml` (and replace the dummy key with pu
 Here we run it from a Docker image:
 
 ```shell
-cat example.yaml | docker run --rm -i quay.io/coreos/ct:latest-dev > /var/lib/libvirt/flatcar-linux/flatcar-linux1/provision.ign
+cat example.yaml | docker run --rm -i ghcr.io/flatcar-linux/ct:latest > /var/lib/libvirt/flatcar-linux/flatcar-linux1/provision.ign
 ```
 
 #### Creating the domain xml

--- a/docs/provisioning/cl-config/_index.md
+++ b/docs/provisioning/cl-config/_index.md
@@ -60,7 +60,7 @@ As shown in this diagram, `ct` is manually invoked only when users are manually 
 
 The Container Linux Config Transpiler abstracts the details of configuring Flatcar Container Linux. It's responsible for transforming a Container Linux Config written by a user into an Ignition Config to be consumed by instances of Flatcar Container Linux.
 
-The Container Linux Config Transpiler command line interface, `ct` for short, can be downloaded from its [GitHub Releases page][download-ct] or used via Docker (`cat example.yaml | docker run --rm -i quay.io/coreos/ct:latest-dev --platform=YOURPLATFORM`).
+The Container Linux Config Transpiler command line interface, `ct` for short, can be downloaded from its [GitHub Releases page][download-ct] or used via Docker (`cat example.yaml | docker run --rm -i ghcr.io/flatcar-linux/ct:latest --platform=YOURPLATFORM`).
 
 The following config will configure an etcd cluster using the machine's public and private IP addresses:
 

--- a/docs/provisioning/config-transpiler/getting-started.md
+++ b/docs/provisioning/config-transpiler/getting-started.md
@@ -11,7 +11,7 @@ ct is a tool that will consume a Container Linux Config and produce a JSON file 
 
 Container Linux Configs are YAML files conforming to ct's schema. For more information on the schema, take a look at [configuration][1].
 
-ct can be downloaded from its [GitHub Releases page][4] or used via Docker (`cat example.yaml | docker run --rm -i quay.io/coreos/ct:latest-dev --platform=YOURPLATFORM`).
+ct can be downloaded from its [GitHub Releases page][4] or used via Docker (`cat example.yaml | docker run --rm -i ghcr.io/flatcar-linux/ct:latest --platform=YOURPLATFORM`).
 
 As a simple example, let's use ct to set the authorized ssh key for the core user on a Container Linux machine.
 


### PR DESCRIPTION
We moved our ct container to ghcr.io - this change updates the documentation accordingly (except for `docs/installing/_index.md` which is updated in https://github.com/flatcar-linux/flatcar-docs/pull/219).