### PR TITLE
Add monitoring section to GCP guide

### DIFF
--- a/docs/installing/cloud/gcp.md
+++ b/docs/installing/cloud/gcp.md
@@ -198,6 +198,95 @@ systemd:
 
 When disabling OS Login functionality on the instance, it is also recommended to disable it in the GCE console.
 
+## Monitoring
+
+Flatcar isn't a supported distro for the
+[Google Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent)
+, as it's designed for traditional operating systems and monitoring the
+processes running on them.
+
+It's likely however that there will be metrics within Flatcar that will be
+useful additions to VM metrics in Google Cloud Monitoring.
+
+### GCP Custom Metrics
+
+Google provide an API and SDKs to ingest custom metrics. For example this
+Python script will send CPU load average and root volume utilisation
+every minute:
+
+**gcp_custom_metrics.py**
+
+```python
+#!/usr/bin/env python3
+from google.cloud import monitoring_v3
+
+import time
+import os
+import shutil
+import requests
+
+metadata_server = "http://metadata/computeMetadata/v1/"
+metadata_flavor = {'Metadata-Flavor' : 'Google'}
+
+gce_name = requests.get(metadata_server + 'instance/hostname', headers = metadata_flavor).text
+gce_project = requests.get(metadata_server + 'project/project-id', headers = metadata_flavor).text
+split_gce_name=gce_name.split(".",2)
+
+client = monitoring_v3.MetricServiceClient()
+project_id = gce_project
+project_name = f"projects/{project_id}"
+
+load_series = monitoring_v3.TimeSeries()
+load_series.metric.type = "custom.googleapis.com/node_load"
+load_series.resource.type = "gce_instance"
+load_series.resource.labels["instance_id"] = split_gce_name[0]
+load_series.resource.labels["zone"] = split_gce_name[1]
+
+du_series = monitoring_v3.TimeSeries()
+du_series.metric.type = "custom.googleapis.com/root_volume_usage"
+du_series.resource.type = "gce_instance"
+du_series.resource.labels["instance_id"] = split_gce_name[0]
+du_series.resource.labels["zone"] = split_gce_name[1]
+
+while True:
+    load1, load5, load15 = os.getloadavg()
+    root_total, root_used, root_free = shutil.disk_usage("/")
+
+    now = time.time()
+    seconds = int(now)
+    nanos = int((now - seconds) * 10 ** 9)
+    interval = monitoring_v3.TimeInterval(
+        {"end_time": {"seconds": seconds, "nanos": nanos}}
+    )
+    load_point = monitoring_v3.Point({"interval": interval, "value": {"double_value": load5}})
+    load_series.points = [load_point]
+    client.create_time_series(request={"name": project_name, "time_series": [load_series]})
+
+    du_point = monitoring_v3.Point({"interval": interval, "value": {"double_value": root_used/root_total}})
+    du_series.points = [du_point]
+    client.create_time_series(request={"name": project_name, "time_series": [du_series]})
+
+    time.sleep(60)
+```
+
+The script can then be packaged up into a Dockerfile:
+
+**Dockerfile**
+
+```dockerfile
+FROM python:3-slim
+
+WORKDIR /usr/src/app
+
+RUN pip3 install --no-cache-dir google-cloud-monitoring
+
+COPY gcp_custom_metrics.py .
+
+CMD [ "python3", "./gcp_custom_metrics.py" ]
+```
+
+The resulting image can then be deployed to a container on each Flatcar node.
+
 ## Using Flatcar Container Linux
 
 Now that you have a machine booted it is time to play around. Check out the [Flatcar Container Linux Quickstart][quickstart] guide or dig into [more specific topics][doc-index].


### PR DESCRIPTION
# Add monitoring section to GCP guide

Note that Google Ops Agent can't be used on Flatcar.

Alternative is to use GCP Custom Metrics.

Sample Python script and Dockerfile.

[Suggested](https://github.com/flatcar-linux/Flatcar/issues/560#issuecomment-1079117250) by @t-lo 

## How to use

The sample script and Dockerfile can be used as is, or people could choose to customise them with additional metrics.

## Testing done

A version of the sample script is in production on The @ Platform infrastructure.

Additional code to create metrics descriptors etc. is in [atsign-company/at_swarm_load](https://github.com/atsign-company/at_swarm_load).

The background story of why this was done was published at [atsign.dev blog : Google Cloud Custom Metrics](https://blog.atsign.dev/google-cloud-custom-metrics-cl16j2q2b05gujonv0h9x2dg5)
