### PR TITLE
Missing Line Continuation

### DIFF
--- a/docs/setup/clusters/booting-on-ecs.md
+++ b/docs/setup/clusters/booting-on-ecs.md
@@ -75,7 +75,7 @@ systemd:
            --volume=/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro \
            --publish=127.0.0.1:51678:51678 \
            --publish=127.0.0.1:51679:51679 \
-           --env=ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs","json-file","journald","logentries","splunk","syslog"]'
+           --env=ECS_AVAILABLE_LOGGING_DRIVERS='["awslogs","json-file","journald","logentries","splunk","syslog"]' \
            --env=ECS_ENABLE_TASK_IAM_ROLE=true \
            --env=ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true \
            --env=ECS_LOGFILE=/log/ecs-agent.log \


### PR DESCRIPTION
# Missing line continuation for ECS_AVAILABLE_LOGGING_DRIVERS

There is a missing line continuation for the docker run command in [Flatcar Container Linux with AWS EC2 Container Service](https://www.flatcar.org/docs/latest/setup/clusters/booting-on-ecs/). When missing the command will fail on that line.

## How to use

To verify this change, build a Flatcar AMI with the Ignition from the [Flatcar Container Linux with AWS EC2 Container Service](https://www.flatcar.org/docs/latest/setup/clusters/booting-on-ecs/). It will no longer fail on the `ECS_AVAILABLE_LOGGING_DRIVERS` line.

## Testing done

I've built a Flatcar-stable-3033.2.4-hvm AMI with Packer sourcing the transpilied Ignition as a `user_data_file`. The built instance no longer fails out while connecting to ECS.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
