### PR TITLE
Update create_cgroupv1_ami.sh

### DIFF
--- a/create_cgroupv1_ami.sh
+++ b/create_cgroupv1_ami.sh
@@ -69,7 +69,7 @@ umount "${TARGET}"
 losetup -d "${LOOP}"
 
 rm -f flatcar_production_ami_vmdk_image-cgroupv1.vmdk
-qemu-img convert -f raw -O vmdk flatcar_production_ami_vmdk_image.vmdk.img flatcar_production_ami_vmdk_image-cgroupv1.vmdk
+qemu-img convert -f raw -O vmdk -o subformat=streamOptimized flatcar_production_ami_vmdk_image.vmdk.img flatcar_production_ami_vmdk_image-cgroupv1.vmdk
 
 rm flatcar_production_ami_vmdk_image.vmdk.img
 echo "Created flatcar_production_ami_vmdk_image-cgroupv1.vmdk from ${VERSION} ${CHANNEL}"


### PR DESCRIPTION
AWS only accepts stream optimized VMDKs, so the final `qemu-img convert` from raw to vmdk needs to
be passed `-o subformat=streamOptimized` so that the vmdk is accepted. There have been reports
of stream vmdk support in qemu-img being buggy, but at least one user report confirms that with this
fix the produced VMDK works (and verity would detect most silent corruption to the image).