### PR TITLE
Add more docs about channels and the update server

### DIFF
--- a/docs/installing/bare-metal/installing-to-disk.md
+++ b/docs/installing/bare-metal/installing-to-disk.md
@@ -82,7 +82,7 @@ For reference here are the rest of the `flatcar-install` options:
             block devices by their major numbers. E.g., -e 7 to exclude loop devices
             or -I 8,259 for certain disk types. Read more about the numbers here:
             https://www.kernel.org/doc/Documentation/admin-guide/devices.txt.
--V VERSION  Version to install (e.g. current)
+-V VERSION  Version to install (e.g. current, or current-2022 for the LTS 2022 stream)
 -B BOARD    Flatcar Container Linux board to use
 -C CHANNEL  Release channel to use (e.g. beta)
 -I|e <M,..> EXPERIMENTAL (used with -s): List of major device numbers to in-/exclude

--- a/docs/setup/releases/switching-channels.md
+++ b/docs/setup/releases/switching-channels.md
@@ -7,13 +7,36 @@ aliases:
     - ../../clusters/management/switching-channels
 ---
 
-Flatcar Container Linux is designed to be updated automatically with different schedules per channel. You can [disable this feature](update-strategies), although we don't recommend it. Read the [release notes](https://flatcar-linux.org/releases) for specific features and bug fixes.
+Flatcar Container Linux is designed to be updated automatically with different schedules per channel. You can [disable this feature](update-strategies), although we don't recommend it.
+Read the [release notes](https://flatcar-linux.org/releases) for specific features, bug fixes, and changes.
+A new major release always starts in the Alpha channel - which is for developers - where it passes multiple feature and bug fix iterations.
+Roughly every second major Alpha release is promoted to the Beta channel; the promotion is based on stability and on feature completeness.
+The Beta channel is for user consumption, so operators can validate compatibility with user workloads.
+In Beta, the release passes additional iterations and eventually fully stabilises, receiving bug fixes addressing issues with user workloads.
+Roughly every second major Beta release is promoted to Stable.
+Thus, the Stable channel gets no brand new major releases but instead gets the bug fix release of a new major release. It then continues to get bug fix releases.
+Any Stable major version remains supported until a new major Stable version is released.
+We generally recommend operators to follow releases in the Stable channel, with a few nodes on Beta for workload validation.
+Beta is generally considered ready for production.
+However, in edge cases new releases may show issues with certain user workloads.
+The Beta channel is an opportunity to validate early and to give feedback, so potential issues are fixed before they hit Stable.
+For low-maintenance scenarios there is the LTS channel which only gets bug fix releases.
+New major releases come out around once per year, marking a new LTS stream, and there is an overlap where the old stream still gets critical security updates.
 
 ![Update Timeline](../../img/update-timeline.png)
 
+By default, Flatcar uses the public update server `public.update.flatcar-linux.net`.
+It promotes the new releases for each channel at the same time they are published.
+If you need more control about the update rollout, you can have a look at the possible [reboot strategies and manual update methods](update-strategies).
+The other alternative is running your own update server which allows you to control the update rollout over your fleet and even divide it into groups that have different rollout policies and release versions.
+The [Nebraska](nebraska) Open Source project implements the update server and is also used for our public instance.
+More on it below and on the Nebraska [docs site](nebraska-docs).
+
 ## Customizing channel configuration
 
-The update engine sources its configuration from `/usr/share/flatcar/update.conf` and `/etc/flatcar/update.conf`.
+An installed image will by default follow the channel it was published in.
+The cloud vendor images (e.g., Alpha, Beta, Stable) and the installer option (`flatcar-install -C <channel>`) are the recommended way of selecting the last release of a channel.
+The update client `update-engine` sources its configuration from `/usr/share/flatcar/update.conf` (baked into the image) and `/etc/flatcar/update.conf` (for user overwrites).
 The former file contains the default hardcoded configuration from the running OS version. Its values cannot be edited, but they can be overridden by the ones in the latter file.
 
 To switch a machine to a different channel, specify the new channel group in `/etc/flatcar/update.conf`:
@@ -40,6 +63,21 @@ sudo mount --bind /tmp/release /usr/share/coreos/release
 
 **Note:** After the update is downloaded and the system is ready to reboot, remove the `GROUP` entry again from `/etc/flatcar/update.conf` because the new update has it as default and there is no need to hardcode it there.
 
+### Freezing an LTS stream
+
+A new LTS major version / stream is released roughly once per year.
+Each LTS major release stream has an 18 month support cycle, so there's a 6 month overlap between new major releases.
+
+The public update channel `GROUP=lts` points to the current LTS release stream.
+This means that it always provides the latest LTS release and, therefore, a major version jump happens when, e.g., the current LTS stream is switched over from `lts-2021` to `lts-2022`.
+Since this can be disruptive depending on the customizations and deployed software, the recommendation is to freeze the LTS stream on deployment and manually switch to a newer LTS stream at one's own pace each year.
+
+The entry in `/etc/flatcar/update.conf` to do so can be added via Ignition or manually (here for only receiving updates for the LTS 2022 stream, i.e., release major version 3033):
+
+```
+GROUP=lts-2022
+```
+
 ## Jump to another channel with `flatcar-update`
 
 With the `flatcar-update` tool you can jump to any release, also from other channels, making you effectively switch the channel. It's worth checking that you didn't hardcode a particular channel as `GROUP` in `/etc/flatcar/update.conf`.
@@ -52,6 +90,29 @@ $ CHANNEL=beta
 $ VER=$(curl -fsSL "https://$CHANNEL.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep FLATCAR_VERSION= | cut -d = -f 2)
 $ sudo flatcar-update --to-version "$VER"
 ```
+
+## Use a personal update server
+
+When setting up your own [Nebraska](nebraska) update server you will be able to point your Flatcar machines to fetch its updates from it.
+Nebraska's web interface allows to create custom groups that are used to specify update rollout policies, and custom channels that specify the Flatcar version.
+Multiple groups can point to the same channel. The Nebraska web interface also gives an overview about the machines and their update status.
+
+It is recommended to start Nebraska with the `-enable-syncer` flag which keeps the Stable, Beta, Alpha, and LTS channels in sync with the public server.
+The default sync interval is one hour but may be shortened (Nebraska option `-sync-interval`). You have to create the `lts-2022' and similar channels if they don't exist on your instance.
+To specify a particular Flatcar version you want to deploy, you should not modify the `stable` *channel* because this gets synced with the public server and your changes are lost.
+You should rather create a new channel and let the `stable` *group* point to it.
+
+For machines with restricted Internet access the Nebraska `-host-flatcar-packages` option lets Nebraska store the update payloads locally when syncing from the public server, and the machines will get your Nebraska's URL to fetch them.
+
+Here is how to configure a machine through `/etc/flatcar/update.conf` to get updates from your personal Nebraska server:
+
+```
+SERVER=http://your.nebraska.host:port/v1/update/
+GROUP=myproduction
+```
+
+More specifics about Nebraska can be found on its [docs site](nebraska-docs).
+
 
 ## Debugging
 
@@ -75,3 +136,6 @@ cat /usr/share/flatcar/update.conf
 ```
 
 Note: while a manual channel switch is in progress, `/usr/share/flatcar/update.conf` shows the channel for the current OS while `/etc/flatcar/update.conf` shows the one for the next update.
+
+[nebraska]: https://github.com/kinvolk/nebraska/
+[nebraska-docs]: https://kinvolk.io/docs/nebraska/latest

--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -11,6 +11,10 @@ The overarching goal of Flatcar Container Linux is to secure the Internet's back
 
 We realize that each Flatcar Container Linux cluster has a unique tolerance for risk and the operational needs of your applications are complex. In order to meet everyone's needs, there are different update/reboot strategies that we have developed.
 
+This document is about the update client and how it consumes the updates when they get available.
+The public update server makes the new releases available as soon as they get published.
+To control this part of the update rollout, look at the different [public update channels and how you can run your own update server](../switching-channels/).
+
 It's important to note that updates are always downloaded to the passive partition when they become available (see further below for disabling automatic updates). A reboot is the last step of the update, where the active and passive partitions are swapped ([rollback instructions][rollback]).
 
 The reboot is done by the reboot manager, by default this is the `locksmithd.service` included on the image.


### PR DESCRIPTION
The docs were a bit sparse about channels and the group entry in
update.conf, specially for the yearly LTS streams. The docs also didn't
talk about setting up an own Nebraska update server for controlling the
update rollout.

Extend the docs about the different channels and how they are
configured in update-engine, with additional info for the LTS streams.
Also recommend the usage of Nebraska and tell shortly how it's used
while pointing to the Nebraska standalone docs for more.

Fixes https://github.com/flatcar-linux/Flatcar/issues/46


## How to use


## Testing done

