### PR TITLE
Document how to avoid mismatching mounts after reboot

### DIFF
--- a/docs/installing/cloud/aws-ec2.md
+++ b/docs/installing/cloud/aws-ec2.md
@@ -109,6 +109,7 @@ storage:
         device: /dev/xvdb
         format: ext4
         wipe_filesystem: true
+        label: ephemeral
 
 systemd:
   units:
@@ -116,7 +117,7 @@ systemd:
       enable: true
       contents: |
         [Mount]
-        What=/dev/xvdb
+        What=/dev/disk/by-label/ephemeral
         Where=/media/ephemeral
         Type=ext4
 

--- a/docs/installing/community-platforms/rackspace.md
+++ b/docs/installing/community-platforms/rackspace.md
@@ -90,7 +90,7 @@ flatcar:
       command: start
       content: |
         [Mount]
-        What=/dev/xvde
+        What=/dev/disk/by-label/FSLABEL
         Where=/media/data
         Type=ext3
 ```


### PR DESCRIPTION
The kernel assigns /dev/sdX nodes by the order the disk is discovered
which can be different each boot. When a path such as /dev/sda is used
for mounting, this can result in a mismatch after reboot.
The better way is to always match the disk by the content that is
expected through the paths under /dev/disk/by-label/ and make sure the
labels get created on the first boot. An alternative when this is not
possible is to use /dev/disk/by-path/.
