### PR TITLE
Correct sysext masking docs

### DIFF
--- a/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
+++ b/docs/container-runtimes/use-a-custom-docker-or-containerd-version.md
@@ -132,11 +132,9 @@ storage:
           runtime_type = "io.containerd.runc.v2"
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
           SystemdCgroup = true
-  links:
-    - path: /etc/extensions/docker-flatcar.raw
-      target: /dev/null
-    - path: /etc/extensions/containerd-flatcar.raw
-      target: /dev/null
+  directories:
+    - path: /etc/extensions/docker-flatcar
+    - path: /etc/extensions/containerd-flatcar
 ```
 
 While the system services have a `PATH` variable that prefers `/opt/bin/` by placing it first, you have to run the following command on every interactive login shell (also after `sudo` or `su`) to make sure you use the correct binaries.

--- a/docs/provisioning/sysext/_index.md
+++ b/docs/provisioning/sysext/_index.md
@@ -59,11 +59,9 @@ storage:
         remote:
           url: https://myserver.net/mydocker.raw
     - path: /etc/systemd/system-generators/torcx-generator
-  links:
-    - path: /etc/extensions/docker-flatcar.raw
-      target: /dev/null
-    - path: /etc/extensions/containerd-flatcar.raw
-      target: /dev/null
+  directories:
+    - path: /etc/extensions/docker-flatcar
+    - path: /etc/extensions/containerd-flatcar
 ```
 
 After boot you can see it loaded in the output of the `systemd-sysext` command:


### PR DESCRIPTION
The instructions used symlinks to /dev/null to "mask" a sysext image
but it turns out that only empty directories work as of now and the
symlink approach actually doesn't which was an oversight in testing.
