### PR TITLE
hardening-guide: Document how to disable the core user

### DIFF
--- a/docs/installing/cloud/equinix-metal.md
+++ b/docs/installing/cloud/equinix-metal.md
@@ -128,6 +128,21 @@ storage:
           set linux_append=""
 ```
 
+To take effect directly on first boot, the alternative is to create a `getty@.service` drop-in, here a CLC snippet:
+
+```
+systemd:
+  units:
+    - name: getty@.service
+      dropins:
+        - name: 10-autologin.conf
+          contents: |
+            [Service]
+            ExecStart=
+            ExecStart=-/sbin/agetty --noclear %I $TERM
+```
+
+
 ## Using Flatcar Container Linux
 
 Now that you have a machine booted it is time to play around. Check out the [Flatcar Container Linux Quickstart][quickstart] guide or dig into [more specific topics][doc-index].

--- a/docs/installing/cloud/vmware.md
+++ b/docs/installing/cloud/vmware.md
@@ -319,6 +319,21 @@ storage:
           set linux_append=""
 ```
 
+To take effect directly on first boot, the alternative is to create a `getty@.service` drop-in, here a CLC snippet:
+
+```
+systemd:
+  units:
+    - name: getty@.service
+      dropins:
+        - name: 10-autologin.conf
+          contents: |
+            [Service]
+            ExecStart=
+            ExecStart=-/sbin/agetty --noclear %I $TERM
+```
+
+
 ## Using Flatcar Container Linux
 
 Now that you have a machine booted, it's time to explore. Check out the [Flatcar Container Linux Quickstart][quickstart] guide, or dig into [more specific topics][docs].

--- a/docs/setup/customization/other-settings.md
+++ b/docs/setup/customization/other-settings.md
@@ -143,6 +143,20 @@ storage:
           set linux_append="$linux_append flatcar.autologin=tty1"
 ```
 
+To take effect directly on first boot, the alternative is to create a `getty@.service` drop-in, here a CLC snippet:
+
+```
+systemd:
+  units:
+    - name: getty@.service
+      dropins:
+        - name: 10-autologin.conf
+          contents: |
+            [Service]
+            ExecStart=
+            ExecStart=-/sbin/agetty --noclear %I $TERM
+```
+
 ### Enable Flatcar Container Linux autologin
 
 To login without a password for the `core` user on the serial or VGA console on every boot, edit `/usr/share/oem/grub.cfg` to add a line like this:

--- a/docs/setup/security/hardening-guide.md
+++ b/docs/setup/security/hardening-guide.md
@@ -82,6 +82,20 @@ Recent Intel CPU vulnerabilities cannot be fully mitigated in software without d
 
 The [SMT on Container Linux guide][smt-guide] provides guidance and instructions for disabling SMT.
 
+### Disable USB
+
+If you don't expect to ever use USB, you can disable the kernel module, here a CLC snippet:
+
+```
+storage:
+  files:
+    - path: /etc/modprobe.d/blacklist.conf
+      mode: 0644
+      contents:
+        inline: |
+          blacklist usb-storage
+```
+
 ### SELinux
 
 SELinux is a fine-grained access control mechanism integrated into Flatcar Container Linux. Each container runs in its own independent SELinux context, increasing isolation between containers and providing another layer of protection should a container be compromised.


### PR DESCRIPTION
Since the group gets provided by nss-altfiles on runtime from the
read-only user DB in /usr, the groups docker and wheel can't be changed
to remove the core user.
The solution to restrict access is to disable the core user, restrict
sudo access, or to
change the permissions of the Docker socket.
The rkt section can be deleted as rkt is gone.
