### PR TITLE
setup/storage/adding-disk-space: update description and link for AWS

### DIFF
--- a/docs/setup/storage/adding-disk-space.md
+++ b/docs/setup/storage/adding-disk-space.md
@@ -12,9 +12,9 @@ On a Flatcar Container Linux machine, the operating system itself is mounted as 
 
 ## Amazon EC2
 
-Amazon doesn't support directly resizing volumes, you must take a snapshot and create a new volume based on that snapshot. Refer to the AWS EC2 documentation on [expanding EBS volumes][ebs-expand-volume] for detailed instructions.
+Amazon doesn't support directly resizing volumes of live machines through the web console, you must either take a snapshot and create a new volume based on that snapshot or use the AWS CLI or other API interface (such as Terraform). Refer to the AWS EC2 documentation on [expanding EBS volumes][ebs-expand-volume] for detailed instructions.
 
-[ebs-expand-volume]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-expand-volume.html
+[ebs-expand-volume]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/requesting-ebs-volume-modifications.html
 
 ## QEMU (qemu-img)
 


### PR DESCRIPTION
# setup/storage/adding-disk-space: update description and link for AWS

AWS EBS volumes made after 2016 can be resized. This adds a link to the documentation on how to do so.

## How to use

Set up an AWS EC2 instance with an EBS volume and run the command `aws ec2 modify-volume --volume-id <ID> --size <NEW SIZE>`. You can verify this on the machine by running `lsblk`.

## Testing done

I used Terraform to set this up, so I simply changed the volume size, reapplied, and went to the machine and ran `lsblk`.

- [] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)