### PR TITLE
Prepare github org rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Submit fixes and additions in the form of [GitHub *Pull Requests* (PRs)][pull-re
 
 1. Fork this repository into your GitHub account
 2. Make changes in a topic branch or your fork's `master`
-3. Send a Pull Request from that topic branch to flatcar-linux/docs
+3. Send a Pull Request from that topic branch to flatcar/flatcar-docs
 4. Maintainers will review the PR and either merge it or make comments
 
 Cognizance of the tribal customs described and linked to below will help get your contributions incorporated with the greatest of ease.
@@ -56,7 +56,7 @@ We happily accept accurate translations. Please send the documents as a pull req
 
 
 [asl]: LICENSE
-[flatcar-docs]: https://docs.flatcar-linux.org
-[help-wanted]: https://github.com/flatcar-linux/docs/issues?q=is%3Aopen+label%3Ahelp-wanted
+[flatcar-docs]: https://www.flatcar.org/docs/latest
+[help-wanted]: https://github.com/flatcar/flatcar-docs/issues?q=is%3Aopen+label%3Ahelp-wanted
 [pull-requests]: https://help.github.com/articles/using-pull-requests/
 [style]: STYLE.md

--- a/NOTICE
+++ b/NOTICE
@@ -7,4 +7,4 @@ The Flatcar Container Linux documentation includes files originally written by
 the CoreOS Container Linux Authors at https://github.com/coreos/docs.
 
 The Flatcar Container Linux documentation is hosted at
-https://github.com/flatcar-linux/docs.
+https://github.com/flatcar/docs.

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Flatcar Container Linux documentation is released under the [Apache 2.0 License]
 [asl]: LICENSE
 [contributing]: CONTRIBUTING.md
 [flatcar-docs]: https://docs.flatcar-linux.org/
-[help-wanted]: https://github.com/flatcar-linux/docs/issues?q=is%3Aopen+label%3Ahelp-wanted
+[help-wanted]: https://github.com/flatcar/docs/issues?q=is%3Aopen+label%3Ahelp-wanted
 [style]: STYLE.md "Flatcar Container Linux Documentation Style and Formatting"

--- a/STYLE.md
+++ b/STYLE.md
@@ -206,7 +206,7 @@ which link will likewise have its label defined at the document's foot.
 
 Using relative URLs where possible helps portability among multiple presentation targets, as they remain valid even as the site root moves. Absolute linking is obviously necessary for resources external to the document's repository and/or the docs.flatcar-linux.org domain.
 
-For example, there are two ways to refer to the [CoreOS quick start guide][quickstart]'s location. The preferred way is a relative link from the current file's path to the target, which from this document is `os/quickstart.md`. An absolute link to the complete URL is less flexible, and more verbose: `https://github.com/flatcar-linux/docs/blob/master/os/quickstart.md`.
+For example, there are two ways to refer to the [CoreOS quick start guide][quickstart]'s location. The preferred way is a relative link from the current file's path to the target, which from this document is `os/quickstart.md`. An absolute link to the complete URL is less flexible, more verbose, and quickly broken like this one: `https://github.com/flatcar-linux/docs/blob/master/os/quickstart.md`.
 
 #### Hyperlink deployment automation
 

--- a/create_cgroupv1_ami.sh
+++ b/create_cgroupv1_ami.sh
@@ -73,6 +73,6 @@ qemu-img convert -f raw -O vmdk -o subformat=streamOptimized flatcar_production_
 
 rm flatcar_production_ami_vmdk_image.vmdk.img
 echo "Created flatcar_production_ami_vmdk_image-cgroupv1.vmdk from ${VERSION} ${CHANNEL}"
-echo "You can upload it with ore (from https://github.com/flatcar-linux/mantle/):"
+echo "You can upload it with ore (from https://github.com/flatcar/mantle/):"
 echo 'ore --credentials-file=$CREDFILE -d aws upload --bucket=s3://$BUCKETNAME/tmp/$ARCH/$VERSION/ --board="$ARCH" --region=$REGION --ami-name="Flatcar-$CHANNEL-$VERSION cgroupv1" --ami-description="Flatcar $CHANNEL $VERSION$SUFFIX cgroupv1" --file="flatcar_production_ami_vmdk_image-cgroupv1.vmdk"'
 end 0

--- a/docs/container-runtimes/switching-to-unified-cgroups.md
+++ b/docs/container-runtimes/switching-to-unified-cgroups.md
@@ -95,7 +95,7 @@ systemd:
 
 Beware that over time it is expected that upstream projects will drop support for cgroups v1.
 
-**Known issues:** Unprivileged containers with user namespaces may lack permissions to access the bind mount ([Flatcar#722](https://github.com/flatcar-linux/Flatcar/issues/722)) and unmounting the bind mount before starting the container is needed.
+**Known issues:** Unprivileged containers with user namespaces may lack permissions to access the bind mount ([Flatcar#722](https://github.com/flatcar/Flatcar/issues/722)) and unmounting the bind mount before starting the container is needed.
 
 ## Generate AWS EC2 cgroups v1 AMIs
 
@@ -157,7 +157,7 @@ For a more detailed discussion of container runtimes, see the [Kubernetes docume
 
 ## Known issues
 
-* `aws/amazon-ecs-agent` does not support `cgroupsv2`: [Flatcar issue](https://github.com/flatcar-linux/Flatcar/issues/585), [AWS issue](https://github.com/aws/containers-roadmap/issues/1535).
+* `aws/amazon-ecs-agent` does not support `cgroupsv2`: [Flatcar issue](https://github.com/flatcar/Flatcar/issues/585), [AWS issue](https://github.com/aws/containers-roadmap/issues/1535).
 * `aws-observability/aws-otel-collector` is segfaulting on a `cgroupsv2` host: [open-telemetry/opentelemetry-collector-contrib#10161](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10161)
 
 

--- a/docs/installing/_index.md
+++ b/docs/installing/_index.md
@@ -33,8 +33,8 @@ Use CLC to customise your Flatcar deployment, e.g. to
 All above tasks only take a few lines of YAML and are covered in our [CLC examples][cl-examples].
 For a comprehensive discussion of all options available in CLC have a look at the [CLC specification][cl-spec].
 
-To convert CLC into machine-readable Ignition config, just download the latest release of the [config transpiler](https://github.com/flatcar-linux/container-linux-config-transpiler/releases) for your platform.
-Alternatively, use our up-to-date [container image](https://github.com/flatcar-linux/container-linux-config-transpiler/pkgs/container/ct): `docker run --rm -i ghcr.io/flatcar-linux/ct:latest`.
+To convert CLC into machine-readable Ignition config, just download the latest release of the [config transpiler](https://github.com/flatcar/container-linux-config-transpiler/releases) for your platform.
+Alternatively, use our up-to-date [container image](https://github.com/flatcar/container-linux-config-transpiler/pkgs/container/ct): `docker run --rm -i ghcr.io/flatcar-linux/ct:latest`.
 
 Then, after converting CLC to Ignition config, pass the Ignition config along when provisioning your instance(s).
 The config is then passed via "user data" / "custom data" or similar means to the provisioning logic.

--- a/docs/installing/cloud/aws-ec2.md
+++ b/docs/installing/cloud/aws-ec2.md
@@ -218,7 +218,7 @@ Now that you have a machine booted it is time to play around. Check out the [Fla
 
 ## Known issues
 
-* `aws/amazon-ecs-agent` does not support `cgroupsv2`: [Flatcar issue](https://github.com/flatcar-linux/Flatcar/issues/585), [AWS issue](https://github.com/aws/containers-roadmap/issues/1535).
+* `aws/amazon-ecs-agent` does not support `cgroupsv2`: [Flatcar issue](https://github.com/flatcar/Flatcar/issues/585), [AWS issue](https://github.com/aws/containers-roadmap/issues/1535).
 
 ## Terraform
 
@@ -482,7 +482,7 @@ Log in via `ssh core@IPADDRESS` with the printed IP address (maybe add `-o Stric
 
 When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` again, the machine will be replaced.
 
-You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar-linux/flatcar-terraform/tree/main/aws).
+You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar/flatcar-terraform/tree/main/aws).
 
 
 [quickstart]: ../

--- a/docs/installing/cloud/azure.md
+++ b/docs/installing/cloud/azure.md
@@ -558,7 +558,7 @@ Log in via `ssh core@IPADDRESS` with the printed IP address.
 
 When you make a change to `cl/machine-mynode.yaml.tmpl` and run `terraform apply` again, the machine will be replaced.
 
-You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar-linux/flatcar-terraform/tree/main/azure).
+You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar/flatcar-terraform/tree/main/azure).
 
 [flatcar-user]: https://groups.google.com/forum/#!forum/flatcar-linux-user
 [etcd-docs]: https://etcd.io/docs

--- a/docs/installing/cloud/equinix-metal.md
+++ b/docs/installing/cloud/equinix-metal.md
@@ -300,4 +300,4 @@ When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` a
 
 It is recommended to register your SSH key in the Equinix Metal Project to use the out-of-band console. Since Flatcar will fetch this key, too, you can remove it from the YAML config.
 
-You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar-linux/flatcar-terraform/tree/main/equinix-metal-aka-packet).
+You can find this Terraform module in the repository for [Flatcar Terraform examples](https://github.com/flatcar/flatcar-terraform/tree/main/equinix-metal-aka-packet).

--- a/docs/installing/community-platforms/exoscale.md
+++ b/docs/installing/community-platforms/exoscale.md
@@ -17,7 +17,7 @@ The Exoscale Flatcar Container Linux image is built officially and each instance
 [reboot-docs]: ../../setup/releases/update-strategies
 [switching-channels]: ../../setup/releases/switching-channels
 [release-notes]: https://flatcar-linux.org/releases
-[cloud-config-docs]: https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md
+[cloud-config-docs]: https://github.com/flatcar/coreos-cloudinit/blob/master/Documentation/cloud-config.md
 
 ## Security groups
 

--- a/docs/installing/community-platforms/notes-for-distributors.md
+++ b/docs/installing/community-platforms/notes-for-distributors.md
@@ -34,7 +34,7 @@ The signing key is rotated annually. We will announce upcoming rotations of the 
 
 ## Image customization
 
-There are two predominant ways that a Flatcar Container Linux image can be easily customized for a specific operating environment: through Ignition, a first-boot provisioning tool that runs during a machine's boot process, and through [cloud-config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md), an older tool that runs every time a machine boots.
+There are two predominant ways that a Flatcar Container Linux image can be easily customized for a specific operating environment: through Ignition, a first-boot provisioning tool that runs during a machine's boot process, and through [cloud-config](https://github.com/flatcar/coreos-cloudinit/blob/master/Documentation/cloud-config.md), an older tool that runs every time a machine boots.
 
 ### Ignition
 

--- a/docs/installing/community-platforms/rackspace.md
+++ b/docs/installing/community-platforms/rackspace.md
@@ -76,7 +76,7 @@ flatcar:
 
 The `$private_ipv4` and `$public_ipv4` substitution variables are fully supported in cloud-config on Rackspace.
 
-[cloud-config-docs]: https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md
+[cloud-config-docs]: https://github.com/flatcar/coreos-cloudinit/blob/master/Documentation/cloud-config.md
 
 ### Mount data disk
 

--- a/docs/installing/community-platforms/vultr.md
+++ b/docs/installing/community-platforms/vultr.md
@@ -34,9 +34,9 @@ sudo flatcar-install -d /dev/vda -c cloud-config.yaml
 sudo reboot
 ```
 
-Please be sure to check out [Using Cloud-Config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md).
+Please be sure to check out [Using Cloud-Config](https://github.com/flatcar/coreos-cloudinit/blob/master/Documentation/cloud-config.md).
 
-You must add to your ssh public key to your `cloud-config`'s [ssh authorized keys](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md#ssh_authorized_keys) so you'll be able to log in.
+You must add to your ssh public key to your `cloud-config`'s [ssh authorized keys](https://github.com/flatcar/coreos-cloudinit/blob/master/Documentation/cloud-config.md#ssh_authorized_keys) so you'll be able to log in.
 
 ## Choosing a channel
 

--- a/docs/installing/customizing-the-image/customize-the-image.md
+++ b/docs/installing/customizing-the-image/customize-the-image.md
@@ -66,10 +66,10 @@ As done on most offered Flatcar cloud images, two additional Ignition files can 
 The first is `base/base.ign` which is always executed as basic mandatory setup.
 The second file `base/default.ign` has a special fallback function and gets executed only if the found instance userdata is not Ignition JSON.
 The common content of the file is to define a systemd service via Ignition that runs `coreos-cloudinit` to process the instance userdata later.
-Good examples are [`base/base.ign`](https://github.com/flatcar-linux/coreos-overlay/blob/ad9c06df2c34be3c6d50ffb80f886bdae10b4809/coreos-base/oem-packet/files/base/base.ign) and [`base/default.ign`](https://github.com/flatcar-linux/coreos-overlay/blob/ad9c06df2c34be3c6d50ffb80f886bdae10b4809/coreos-base/oem-packet/files/base/default.ign) files used for Equinix Metal images as they also make use of the `oem:///` source URL to refer to a file placed on the OEM partition.
+Good examples are [`base/base.ign`](https://github.com/flatcar/coreos-overlay/blob/ad9c06df2c34be3c6d50ffb80f886bdae10b4809/coreos-base/oem-packet/files/base/base.ign) and [`base/default.ign`](https://github.com/flatcar/coreos-overlay/blob/ad9c06df2c34be3c6d50ffb80f886bdae10b4809/coreos-base/oem-packet/files/base/default.ign) files used for Equinix Metal images as they also make use of the `oem:///` source URL to refer to a file placed on the OEM partition.
 
 The `grub.cfg` file gets sourced by GRUB to set up the OEM ID which is used by systemd units to be started conditionally, or to set up kernel parameters like the Ignition config URL (`ignition.config.url`, to fetch the preferred config remotely), or settings required for the hardware.
-Again, a good example is the [`grub.cfg` file](https://github.com/flatcar-linux/coreos-overlay/blob/ad9c06df2c34be3c6d50ffb80f886bdae10b4809/coreos-base/oem-packet/files/grub.cfg) used for Equinix Metal images to set the OEM ID and the kernel parameter `flatcar.autologin` to be able to use the serial console without having to configure a user password.
+Again, a good example is the [`grub.cfg` file](https://github.com/flatcar/coreos-overlay/blob/ad9c06df2c34be3c6d50ffb80f886bdae10b4809/coreos-base/oem-packet/files/grub.cfg) used for Equinix Metal images to set the OEM ID and the kernel parameter `flatcar.autologin` to be able to use the serial console without having to configure a user password.
 
 ### Customizing the root partition
 

--- a/docs/installing/vms/virtualbox.md
+++ b/docs/installing/vms/virtualbox.md
@@ -77,7 +77,7 @@ Cloud-config can be specified by attaching a [config-drive](https://github.com/k
 
 Note that the config-drive standard was originally an OpenStack feature, which is why you'll see strings containing `openstack`. This filepath needs to be retained, although Flatcar Container Linux supports config-drive on all platforms.
 
-For more information on customization that can be done with cloud-config, head on over to the [cloud-config guide](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md).
+For more information on customization that can be done with cloud-config, head on over to the [cloud-config guide](https://github.com/flatcar/coreos-cloudinit/blob/master/Documentation/cloud-config.md).
 
 You need a config-drive to configure at least one SSH key to access the virtual machine. If you are in hurry, you can create a basic config-drive with following steps:
 

--- a/docs/provisioning/sysext/_index.md
+++ b/docs/provisioning/sysext/_index.md
@@ -18,7 +18,7 @@ Systemd-sysext is supported in Flatcar versions ≥ 3185.0.0 for user provided s
 ## Torcx deprecation
 
 Since systemd-sysext is a more generic and maintained solution than Torcx, it will replace Torcx and Torcx is scheduled for removal from Flatcar at some point in the future (no date or major release version yet).
-Starting from Flatcar version 3185.0.0 we encourage you to migrate any Torcx usage and convert your Torcx image with the `convert_torcx_image.sh` helper script from the [`sysext-bakery`](https://github.com/flatcar-linux/sysext-bakery) repository, mentioned later in this document.
+Starting from Flatcar version 3185.0.0 we encourage you to migrate any Torcx usage and convert your Torcx image with the `convert_torcx_image.sh` helper script from the [`sysext-bakery`](https://github.com/flatcar/sysext-bakery) repository, mentioned later in this document.
 
 ## The sysext format
 
@@ -78,7 +78,7 @@ A manual `systemd-sysext refresh` is not recommended.
 
 ## Creating custom sysext images
 
-The [`sysext-bakery`](https://github.com/flatcar-linux/sysext-bakery) repository under the Flatcar GitHub organization serves as a central point for sysext building tools.
+The [`sysext-bakery`](https://github.com/flatcar/sysext-bakery) repository under the Flatcar GitHub organization serves as a central point for sysext building tools.
 Please reach out if your use case isn't covered and work with us to include it there.
 
 ### Upstream Docker sysext images

--- a/docs/reference/developer-guides/_index.md
+++ b/docs/reference/developer-guides/_index.md
@@ -23,4 +23,4 @@ We also provide OEM functionality for cloud providers and similar use cases to c
 [mod-cl]: sdk-modifying-flatcar
 [kernel-modules]: kernel-modules
 [sdk-bootstrapping]: sdk-bootstrapping
-[mantle-utils]: https://github.com/flatcar-linux/mantle/blob/flatcar-master/README.md#kola
+[mantle-utils]: https://github.com/flatcar/mantle/blob/flatcar-master/README.md#kola

--- a/docs/reference/developer-guides/sdk-building-production-images.md
+++ b/docs/reference/developer-guides/sdk-building-production-images.md
@@ -53,7 +53,7 @@ A good way to look at releases and stabilisation through channels is to consider
 ## On versioning
 
 For Flatcar versioning, the scripts repo is authoritative: 
-Versioning is controlled by the [`version.txt` file in the scripts repo](https://github.com/flatcar-linux/scripts/blob/main/sdk_container/.repo/manifests/version.txt) as well as via the commit pointers of the script repo's `portage-stable` and `coreos-overlay` gitmodules.
+Versioning is controlled by the [`version.txt` file in the scripts repo](https://github.com/flatcar/scripts/blob/main/sdk_container/.repo/manifests/version.txt) as well as via the commit pointers of the script repo's `portage-stable` and `coreos-overlay` gitmodules.
 `version.txt` contains version strings for both the SDK version as well as the OS image version.
 
 Core idea is that a simple
@@ -118,11 +118,11 @@ The [build automation scripts][scripts-repo-ci] reflect the 5 steps outlined abo
 Check out the build automation's `README.md` to get an overview.
 Each of the scripts contains documentation of the inputs and outputs of the respective build step:
 
-1. [`sdk_bootstrap.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/sdk_bootstrap.sh) builds a new SDK tarball from scratch
-2. [`sdk_container.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/sdk_container.sh) builds an SDK container image from a tarball
-3. [`packages.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/packages.sh) builds all binary packages for an OS image
-4. [`image.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/image.sh) builds a generic OS image
-5. [`vms.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/vms.sh) builds vendor-specific images
+1. [`sdk_bootstrap.sh`](https://github.com/flatcar/scripts/blob/main/ci-automation/sdk_bootstrap.sh) builds a new SDK tarball from scratch
+2. [`sdk_container.sh`](https://github.com/flatcar/scripts/blob/main/ci-automation/sdk_container.sh) builds an SDK container image from a tarball
+3. [`packages.sh`](https://github.com/flatcar/scripts/blob/main/ci-automation/packages.sh) builds all binary packages for an OS image
+4. [`image.sh`](https://github.com/flatcar/scripts/blob/main/ci-automation/image.sh) builds a generic OS image
+5. [`vms.sh`](https://github.com/flatcar/scripts/blob/main/ci-automation/vms.sh) builds vendor-specific images
 
 CI / build automation infrastructure should set up the steps in a build pipeline.
 Artifacts of a preceding build step are fed into the succeeding step.
@@ -138,7 +138,7 @@ Apart from infrastructure to run the CI / builds on we also need a server for ca
 Build artifacts are mostly container images - with only few exceptions - and are almost always huge (some gigabytes).
 To not overly pollute CI workers' disk space, the build scripts support an "artifact cache" server.
 Requirements for this server are rather simple - it should have sufficient disk space (we use 7TB on Flatcar's CI and can hold ~50 past builds), ssh access (for rsync) and serve artifacts from the (rsync/ssh) path prefix via HTTPS.
-See the `BUILDCACHE_…` settings in the [CI automation settings file](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/ci-config.env) for adapting the build scripts to your environment.
+See the `BUILDCACHE_…` settings in the [CI automation settings file](https://github.com/flatcar/scripts/blob/main/ci-automation/ci-config.env) for adapting the build scripts to your environment.
 
-[scripts-repo-ci]: https://github.com/flatcar-linux/scripts/tree/main/ci-automation
+[scripts-repo-ci]: https://github.com/flatcar/scripts/tree/main/ci-automation
 [mod-cl]: sdk-modifying-flatcar

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -31,7 +31,7 @@ Please note these resources might be outdated and only this page reflects the mo
 
 **tl;dr** Check out a release branch and start the SDK (this uses the current Alpha release branch).
 ```shell
-$ git clone --recurse-submodules https://github.com/flatcar-linux/scripts.git
+$ git clone --recurse-submodules https://github.com/flatcar/scripts.git
 $ cd scripts
 $ branch="$(git branch -r -l | sed -n 's:origin/\(flatcar-[0-9]\+\)$:\1:p' | sort | tail -n1)"
 $ ./checkout "$branch"
@@ -71,7 +71,7 @@ The [scripts repository][scripts] - among other things - contains SDK wrapper sc
 A good way to think of the scripts repo is this being Flatcar's "SDK repo".
 
 ```shell
-$ git clone --recurse-submodules https://github.com/flatcar-linux/scripts.git
+$ git clone --recurse-submodules https://github.com/flatcar/scripts.git
 $ cd scripts
 ```
 
@@ -305,7 +305,7 @@ Furthermore, each package directory contains a `Manifest` file with cryptographi
 Multiple package sources - in separate directories - can be stacked on top of each other.
 These “overlays” allow custom extensions or even custom sub-trees on top of an existing foundation.
 In these stacks, “upper” level packages override “lower” level ones.
-The Flatcar build system uses a fork of Gentoo upstream’s [portage-stable](https://github.com/flatcar-linux/portage-stable) as its base, and the overlay repository [coreos-overlay](https://github.com/flatcar-linux/coreos-overlay) for Flatcar specific modifications and packages on top.
+The Flatcar build system uses a fork of Gentoo upstream’s [portage-stable](https://github.com/flatcar/portage-stable) as its base, and the overlay repository [coreos-overlay](https://github.com/flatcar/coreos-overlay) for Flatcar specific modifications and packages on top.
 
 Packages are built using "ebuild" files.
 These files contain dependencies of a package - both build and runtime - as well as implement callbacks for downloading, patching, building, and installing the package.
@@ -673,16 +673,16 @@ Take a look at the [SDK bootstrap process](sdk-bootstrapping) to learn how to bu
 [Mantle][mantle] is a collection of utilities used in testing and launching SDK images.
 
 [flatcar-dev]: https://groups.google.com/forum/#!forum/flatcar-linux-dev
-[github-flatcar]: https://github.com/flatcar-linux
+[github-flatcar]: https://github.com/flatcar
 [matrix]: https://app.element.io/#/room/#flatcar:matrix.org
 [ghcr-sdk]: https://github.com/orgs/flatcar-linux/packages
-[scripts]: https://github.com/flatcar-linux/scripts
+[scripts]: https://github.com/flatcar/scripts
 [flatcar-releases]: https://www.flatcar-linux.org/releases/
 
 
-[coreos]: https://github.com/flatcar-linux/coreos-overlay
-[portage]: https://github.com/flatcar-linux/portage-stable
-[mantle]: https://github.com/flatcar-linux/mantle
+[coreos]: https://github.com/flatcar/coreos-overlay
+[portage]: https://github.com/flatcar/portage-stable
+[mantle]: https://github.com/flatcar/mantle
 [prodimages]: sdk-building-production-images
 [sdktips]: sdk-tips-and-tricks
 [booting-qemu]: ../../installing/vms/qemu/#ssh-keys

--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -18,7 +18,7 @@ To control this part of the update rollout, look at the different [public update
 It's important to note that updates are always downloaded to the passive partition when they become available (see further below for disabling automatic updates). A reboot is the last step of the update, where the active and passive partitions are swapped ([rollback instructions][rollback]).
 
 The reboot is done by the reboot manager, by default this is the `locksmithd.service` included on the image.
-For Kubernetes the recommended reboot manager is [FLUO](https://github.com/flatcar-linux/flatcar-linux-update-operator/) which replaces locksmithd because it knows how to gracefully reboot a Kubernetes node.
+For Kubernetes the recommended reboot manager is [FLUO](https://github.com/flatcar/flatcar-linux-update-operator/) which replaces locksmithd because it knows how to gracefully reboot a Kubernetes node.
 The [kured](https://github.com/weaveworks/kured) reboot manager will be supported as well starting from Flatcar versions with a release number greater than `3067.0.0`.
 
 The `update-engine.service` responsible for downloading and applying the updates can be in different states which you can query with `update_engine_client -status`:

--- a/docs/setup/security/selinux.md
+++ b/docs/setup/security/selinux.md
@@ -52,4 +52,4 @@ Now, edit `/etc/selinux/config` to replace `SELINUX=permissive` with `SELINUX=en
 
 
 [gh-flatcar]: https://github.com/kinvolk/Flatcar/issues
-[flannel-issue]: https://github.com/flatcar-linux/Flatcar/issues/635
+[flannel-issue]: https://github.com/flatcar/Flatcar/issues/635


### PR DESCRIPTION
The "flatcar-linux" org will be renamed to "flatcar". For renames, there are no redirections in place and we have to update all links.


## How to use

Merge when rename is done