### PR TITLE
kubernetes: mention that 1.23 is not tested anymore

### DIFF
--- a/docs/container-runtimes/getting-started-with-kubernetes.md
+++ b/docs/container-runtimes/getting-started-with-kubernetes.md
@@ -15,7 +15,7 @@ A Kubernetes basic scenario (deploy a simple Nginx) is being tested on Flatcar a
 One way to contribute to Flatcar would be to extend the covered CNIs (example: [kubenet][kubenet]) or to provide more complex scenarios (example: [cilium extension][cilium]).
 
 This is a compatibility matrix between Flatcar and Kubernetes:
-| Flatcar channel \ Kubernetes Version | 1.23               | 1.24               | 1.25               | 1.26               |
+| :arrow_down: Flatcar channel \ Kubernetes Version :arrow_right: | 1.23               | 1.24               | 1.25               | 1.26               |
 |--------------------------------------|--------------------|--------------------|--------------------|--------------------|
 | Alpha                                | :large_orange_diamond: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Beta                                 | :large_orange_diamond: | :white_check_mark: | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
For correct matrix rendering, we have this PR: https://github.com/flatcar/flatcar-website/pull/256