### PR TITLE
container-runtimes/docker: remove docker.socket deactivation

### DIFF
--- a/docs/container-runtimes/getting-started-with-docker.md
+++ b/docs/container-runtimes/getting-started-with-docker.md
@@ -102,9 +102,7 @@ Here is a Container Linux Config to enable the Docker service while disabling so
 ```yaml
 systemd:
   units:
-    # Ensure docker starts automatically instead of being socket-activated
-    - name: docker.socket
-      enabled: false
+    # Ensure docker starts automatically instead of being only socket-activated
     - name: docker.service
       enabled: true
 ```


### PR DESCRIPTION
This socket deactivation is useless (and never worked since a while) as the socket is anyway always activated by Torcx.

Enabling the Docker service is enough to have container restarting at boot.

<hr>

Related to: https://github.com/flatcar/Flatcar/issues/1004