### PR TITLE
qemu: change '-curses' for '-display curses'

### DIFF
--- a/docs/container-runtimes/getting-started-with-kubernetes.md
+++ b/docs/container-runtimes/getting-started-with-kubernetes.md
@@ -118,7 +118,7 @@ This minimal configuration can be used with Flatcar on QEMU (:warning: be sure t
 
 ```bash
 butane < config.yaml > config.json
-./flatcar_production_qemu.sh -i config.json -- -curses
+./flatcar_production_qemu.sh -i config.json -- -display curses
 kubectl get nodes
 NAME        STATUS     ROLES           AGE    VERSION
 localhost   NotReady   control-plane   6m5s   v1.26.0

--- a/docs/installing/bare-metal/booting-with-ipxe.md
+++ b/docs/installing/bare-metal/booting-with-ipxe.md
@@ -126,7 +126,7 @@ We will use `qemu-kvm` in this guide but use whatever process you normally use f
 
 ```shell
 wget http://boot.ipxe.org/ipxe.iso
-qemu-kvm -m 1024 ipxe.iso --curses
+qemu-kvm -m 1024 ipxe.iso -display curses
 ```
 
 Next press Ctrl+B to get to the iPXE prompt and type in the following commands:

--- a/docs/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/docs/reference/developer-guides/sdk-modifying-flatcar.md
@@ -270,11 +270,11 @@ If you encounter errors with KVM, verify that virtualization is supported by you
 
 #### Boot Options
 
-After `image_to_vm.sh` completes, run `./flatcar_production_qemu.sh -curses` to launch a graphical interface to log in to the Flatcar Container Linux VM.
+After `image_to_vm.sh` completes, run `./flatcar_production_qemu.sh -- -display curses` to launch a graphical interface to log in to the Flatcar Container Linux VM.
 
 You could instead use the `-nographic` option, `./flatcar_production_qemu.sh -nographic`, which gives you the ability to switch from the VM to the QEMU monitor console by pressing <kbd>CTRL</kbd>+<kbd>a</kbd> and then <kbd>c</kbd>. To close the Flatcar Container Linux Guest OS VM, run `sudo systemctl poweroff` inside the VM.
 
-You can log in via SSH keys or with a different ssh port by running this example `./flatcar_production_qemu.sh -a ~/.ssh/authorized_keys -p 2223 -- -curses`. Refer to the [Booting with QEMU][booting-qemu] guide for more information on this usage.
+You can log in via SSH keys or with a different ssh port by running this example `./flatcar_production_qemu.sh -a ~/.ssh/authorized_keys -p 2223 -- -display curses`. Refer to the [Booting with QEMU][booting-qemu] guide for more information on this usage.
 
 ## Making changes
 


### PR DESCRIPTION
See also: https://qemu-project.gitlab.io/qemu/about/removed-features.html#curses-removed-in-7-1

<hr>

Noticed while using qemu documentation reference in Flatcar tutorial