### PR TITLE
docs/tutorial: links fix

### DIFF
--- a/docs/tutorial/_index.md
+++ b/docs/tutorial/_index.md
@@ -23,8 +23,8 @@ For each covered item, there is a demo and a few lines to explain what's going o
 * [Hands-on 3][hands-on-3]: Deploying
 * [Hands-on 4][hands-on-4]: Updating
 
-[hands-on-1]: ./tutorial/hands-on-1
-[hands-on-2]: ./tutorial/hands-on-2
-[hands-on-3]: ./tutorial/hands-on-3
-[hands-on-4]: ./tutorial/hands-on-4
-[quickstart]: ./installing
+[hands-on-1]: tutorial/hands-on-1
+[hands-on-2]: tutorial/hands-on-2
+[hands-on-3]: tutorial/hands-on-3
+[hands-on-4]: tutorial/hands-on-4
+[quickstart]: installing

--- a/docs/tutorial/hands-on-1/_index.md
+++ b/docs/tutorial/hands-on-1/_index.md
@@ -48,7 +48,7 @@ curl localhost
 
 # Resources
 
-* [documentation][./installing/vms/qemu/#startup-flatcar-container-linux]
+* [documentation][installing/vms/qemu/#startup-flatcar-container-linux]
 
 # Demo
 


### PR DESCRIPTION
I noticed when checking the website preview from the release