### PR TITLE
update-strategies: add missing "overwrite: true"

### DIFF
--- a/docs/setup/releases/update-strategies.md
+++ b/docs/setup/releases/update-strategies.md
@@ -56,6 +56,7 @@ version: 1.0.0
 storage:
   files:
     - path: /etc/flatcar/update.conf
+      overwrite: true
       contents:
         inline: |
           REBOOT_STRATEGY=etcd-lock
@@ -72,6 +73,7 @@ This gets transpiled to the following Ignition configuration which writes the li
   "storage": {
     "files": [
       {
+        "overwrite": true,
         "path": "/etc/flatcar/update.conf",
         "contents": {
           "compression": "",
@@ -137,6 +139,7 @@ version: 1.0.0
 storage:
   files:
     - path: /etc/flatcar/update.conf
+      overwrite: true
       contents:
         inline: |
           REBOOT_STRATEGY=reboot
@@ -172,6 +175,7 @@ version: 1.0.0
 storage:
   files:
     - path: /etc/flatcar/update.conf
+      overwrite: true
       mode: 0644
       contents:
         inline: |


### PR DESCRIPTION
Our butane examples for customising locksmith contain an error: `overwrite: true` is missing when modifying `update.conf`. This leads to ignition panicking during provisioning as `update.conf` already exists:

```
ignition[1009]: CRITICAL : Ignition failed: failed to create files: failed to create files: error creating /sysroot/etc/flatcar/update.conf: error creating file "/sysroot/etc/flatcar/update.conf": A file exists there already and overwrite is false
```

This change updates our examples and adds `overwrite:true`.