### PR TITLE
Skip the unpacking of the QEMU image

### DIFF
--- a/docs/installing/_index.md
+++ b/docs/installing/_index.md
@@ -49,8 +49,7 @@ First download the Flatcar QEMU image and the helper script to start it with QEM
 ```shell
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 chmod +x flatcar_production_qemu.sh
-wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
-bunzip2 flatcar_production_qemu_image.img.bz2
+wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
 ```
 
 For Ignition configurations to be recognized we have to make sure that we always boot an unmodified fresh image because Ignition only runs on first boot.

--- a/docs/installing/vms/libvirt.md
+++ b/docs/installing/vms/libvirt.md
@@ -38,9 +38,8 @@ Flatcar Container Linux is designed to be updated automatically with different s
       <pre>
 mkdir -p /var/lib/libvirt/images/flatcar-linux
 cd /var/lib/libvirt/images/flatcar-linux
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2{,.sig}
-gpg --verify flatcar_production_qemu_image.img.bz2.sig
-bunzip2 flatcar_production_qemu_image.img.bz2</pre>
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img{,.sig}
+gpg --verify flatcar_production_qemu_image.img.sig</pre>
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
@@ -48,9 +47,8 @@ bunzip2 flatcar_production_qemu_image.img.bz2</pre>
       <pre>
 mkdir -p /var/lib/libvirt/images/flatcar-linux
 cd /var/lib/libvirt/images/flatcar-linux
-wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2{,.sig}
-gpg --verify flatcar_production_qemu_image.img.bz2.sig
-bunzip2 flatcar_production_qemu_image.img.bz2</pre>
+wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img{,.sig}
+gpg --verify flatcar_production_qemu_image.img.sig</pre>
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
@@ -58,9 +56,9 @@ bunzip2 flatcar_production_qemu_image.img.bz2</pre>
       <pre>
 mkdir -p /var/lib/libvirt/images/flatcar-linux
 cd /var/lib/libvirt/images/flatcar-linux
-wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2{,.sig}
-gpg --verify flatcar_production_qemu_image.img.bz2.sig
-bunzip2 flatcar_production_qemu_image.img.bz2</pre>
+wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img{,.sig}
+gpg --verify flatcar_production_qemu_image.img.sig
+bunzip2 flatcar_production_qemu_image.img</pre>
     </div>
   </div>
 </div>
@@ -251,8 +249,7 @@ First, prepare the base image and make sure you don't boot it via the [`flatcar_
 
 ```sh
 cd ~/Downloads
-wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
-bunzip2 flatcar_production_qemu_image.img.bz2
+wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
 mv flatcar_production_qemu_image.img flatcar_production_qemu_image-libvirt-import.img
 # optional, increase the image by 5 GB:
 qemu-img resize flatcar_production_qemu_image-libvirt-import.img +5G

--- a/docs/installing/vms/qemu.md
+++ b/docs/installing/vms/qemu.md
@@ -83,11 +83,10 @@ Flatcar Container Linux is designed to be updated automatically with different s
       <pre>mkdir flatcar; cd flatcar
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
-wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
-wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2.sig
+wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
+wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.sig
 gpg --verify flatcar_production_qemu.sh.sig
-gpg --verify flatcar_production_qemu_image.img.bz2.sig
-bzip2 -d flatcar_production_qemu_image.img.bz2
+gpg --verify flatcar_production_qemu_image.img.sig
 chmod +x flatcar_production_qemu.sh</pre>
     </div>
     <div class="tab-pane" id="alpha">
@@ -99,11 +98,10 @@ chmod +x flatcar_production_qemu.sh</pre>
       <pre>mkdir flatcar; cd flatcar
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2.sig
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.sig
 gpg --verify flatcar_production_qemu.sh.sig
-gpg --verify flatcar_production_qemu_image.img.bz2.sig
-bzip2 -d flatcar_production_qemu_image.img.bz2
+gpg --verify flatcar_production_qemu_image.img.sig
 chmod +x flatcar_production_qemu.sh</pre>
     </div>
     <div class="tab-pane" id="beta">
@@ -115,11 +113,10 @@ chmod +x flatcar_production_qemu.sh</pre>
       <pre>mkdir flatcar; cd flatcar
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
-wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
-wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2.sig
+wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
+wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.sig
 gpg --verify flatcar_production_qemu.sh.sig
-gpg --verify flatcar_production_qemu_image.img.bz2.sig
-bzip2 -d flatcar_production_qemu_image.img.bz2
+gpg --verify flatcar_production_qemu_image.img.sig
 chmod +x flatcar_production_qemu.sh</pre>
     </div>
   </div>

--- a/docs/tutorial/hands-on-1/_index.md
+++ b/docs/tutorial/hands-on-1/_index.md
@@ -17,11 +17,13 @@ mkdir flatcar; cd flatcar
 # get the qemu helper
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 # get the latest stable release for qemu
-wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
-# extract the downloaded image
-bzip2 --decompress --keep flatcar_production_qemu_image.img.bz2
+wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
+# create a backup to always have a fresh image around
+mv flatcar_production_qemu_image.img flatcar_production_qemu_image.img.fresh
 # make the qemu helper executable
 chmod +x flatcar_production_qemu.sh
+# before starting, make sure you boot a fresh image
+cp -i --reflink=auto flatcar_production_qemu_image.img.fresh flatcar_production_qemu_image.img
 # starts the flatcar image in console mode
 ./flatcar_production_qemu.sh -- -display curses
 ```

--- a/docs/tutorial/hands-on-2/_index.md
+++ b/docs/tutorial/hands-on-2/_index.md
@@ -28,10 +28,9 @@ storage:
 ```
 $ docker run --rm -i quay.io/coreos/butane:latest < config.yaml > config.json
 ```
-* Download a Flatcar image (or use the zipped one from previous hands-on). NOTE: Ignition runs at first boot, it won't work if you reuse your the previously booted image, always decompress again each time you change your Ignition config.
+* Use a fresh Flatcar image from the previous hands-on (or download again). NOTE: Ignition runs at first boot, it won't work if you reuse your the previously booted image, always decompress again each time you change your Ignition config.
 ```
-cp ../hands-on-1/flatcar_production_qemu_image.img.bz2 .
-bzip2 --decompress --keep ./flatcar_production_qemu_image.img.bz2
+cp -i --reflink=auto ../hands-on-1/flatcar_production_qemu_image.img.fresh flatcar_production_qemu_image.img
 chmod +x flatcar_production_qemu.sh
 ```
 * Start the image with Ignition configuration (`-i ./config.json`)

--- a/docs/tutorial/hands-on-4/_index.md
+++ b/docs/tutorial/hands-on-4/_index.md
@@ -18,10 +18,9 @@ Hint: two services are used:
 
 ```
 # download a previous version of Flatcar and the qemu helper
-$ wget https://stable.release.flatcar-linux.net/amd64-usr/3374.2.5/flatcar_production_qemu_image.img.bz2
-$ wget https://stable.release.flatcar-linux.net/amd64-usr/3374.2.5/flatcar_production_qemu.sh
+$ wget https://stable.release.flatcar-linux.net/amd64-usr/3602.2.0/flatcar_production_qemu_image.img
+$ wget https://stable.release.flatcar-linux.net/amd64-usr/3602.2.0/flatcar_production_qemu.sh
 $ chmod +x flatcar_production_qemu.sh
-$ bzip2 --decompress ./flatcar_production_qemu_image.img.bz2
 # boot the instance with the nginx Ignition from a previous lab
 $ ./flatcar_production_qemu.sh -i ../hands-on-2/config.json -- -display curses
 # assert that `locksmithd.service` and `update-engine` are up and running


### PR DESCRIPTION
We now provide the qcow2 image with inline compression. This means we can skip the unpacking. This is available from Stable 3602.2.0 and the hands-on 4 tutorial was updated to this version - hence we should wait for 3602.2.1 to be out before merging this change.

## Testing done

None