### PR TITLE
torcx/index: quote '[]'

### DIFF
--- a/docs/provisioning/torcx/_index.md
+++ b/docs/provisioning/torcx/_index.md
@@ -1,5 +1,5 @@
 ---
-title: [DEPRECATED / EOL] Torcx
+title: "[DEPRECATED / EOL] Torcx"
 description: Addon manager for applying ephemeral changes
 weight: 100
 aliases:


### PR DESCRIPTION
Otherwise YAML parser is not happy:
```
Error: Error building site: "/home/runner/work/flatcar-website/flatcar-website/content/docs/latest/provisioning/torcx/_index.md:2:1": failed to unmarshal YAML: yaml: did not find expected key
```

Noticed here: https://github.com/flatcar/flatcar-website/pull/281 (nightly documentation build was failing too).

Locally tested.